### PR TITLE
[chore] add renovate group name

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:best-practices",
-    "helpers:pinGitHubActionDigestsToSemver"
+    "helpers:pinGitHubActionDigestsToSemver",
+    "schedule:weekly"
   ],
   "packageRules": [
     {
+      "groupName": "all",
       "matchUpdateTypes": ["minor", "major", "patch"],
       "schedule": ["before 8am on Monday"]
     }


### PR DESCRIPTION
PR #109 removed the renovate group name, this change adds the group name back. The intent is to group Renovate dependency updates so the chore of merging and these becomes more bearable.