### PR TITLE
[nodejs] add testing and fix issues

### DIFF
--- a/.chloggen/nodejs_testing.yaml
+++ b/.chloggen/nodejs_testing.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: nodejs
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: test nodeJS support
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [127]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Testing identified issues with the RPM and Debian packages.
+  The Debian and RPM packages now contain the nodeJS dependencies organized in a folder structure rather than an archive.
+  The configuration points correctly to the file to load to launch autoinstrumentation.
+  
+  NodeJS tests now run as part of CI.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
     strategy:
       matrix:
         SYS_PACKAGE: [ "deb", "rpm" ]
-        lang: [ "java" ]
+        lang: [ "java", "nodejs" ]
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/packaging/fpm/common.sh
+++ b/packaging/fpm/common.sh
@@ -27,6 +27,7 @@ JAVA_AGENT_INSTALL_PATH="${INSTALL_DIR}/javaagent.jar"
 
 NODEJS_AGENT_RELEASE_PATH="${FPM_DIR}/../nodejs-agent-release.txt"
 NODEJS_AGENT_INSTALL_PATH="${INSTALL_DIR}/otel-js.tgz"
+NODEJS_AGENT_INSTALL_DIR="${INSTALL_DIR}/js"
 
 DOTNET_AGENT_RELEASE_PATH="${FPM_DIR}/../dotnet-agent-release.txt"
 DOTNET_ARTIFACE_BASE_NAME="opentelemetry-dotnet-instrumentation"
@@ -68,10 +69,14 @@ download_java_agent() {
 download_nodejs_agent() {
     local tag="$1"
     local dest="$2"
-    mkdir -p "$( dirname $dest )"
-    pushd "$( dirname $dest )"
+    pushd "$(dirname "$dest")"
+    mkdir -p "js"
+    pushd "js"
     npm pack @opentelemetry/auto-instrumentations-node@${tag#v}
     mv *.tgz otel-js.tgz
+    npm install --global=false otel-js.tgz
+    rm otel-js.tgz
+    popd
     popd
 }
 
@@ -130,7 +135,7 @@ setup_files_and_permissions() {
     sudo chmod 755 "$buildroot/$JAVA_AGENT_INSTALL_PATH"
 
     download_nodejs_agent "$nodejs_agent_release" "${buildroot}/${NODEJS_AGENT_INSTALL_PATH}"
-    sudo chmod 755 "$buildroot/$NODEJS_AGENT_INSTALL_PATH"
+    sudo chmod -R 755 "$buildroot/$NODEJS_AGENT_INSTALL_DIR"
 
     download_dotnet_agent "$dotnet_agent_release" "${buildroot}/${DOTNET_AGENT_INSTALL_DIR}"
     sudo chmod -R 755 "$buildroot/$DOTNET_AGENT_INSTALL_DIR"

--- a/packaging/fpm/etc/opentelemetry/otelinject.conf
+++ b/packaging/fpm/etc/opentelemetry/otelinject.conf
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet
 jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/javaagent.jar
-nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/otel-js/node_modules/@opentelemetry-js/otel/instrument
+nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/js/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js

--- a/packaging/tests/deb/nodejs/Dockerfile
+++ b/packaging/tests/deb/nodejs/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:12
+
+ARG ARCH=amd64
+
+RUN apt-get update
+RUN apt install -y nodejs npm wget
+
+RUN mkdir my_express_app && \
+    cd my_express_app && \
+    npm init -y && \
+    npm install express --save
+
+
+# TODO The otel collector version needs to be kept up to date, potentially with renovate.
+RUN wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.128.0/otelcol-contrib_0.128.0_linux_${ARCH}.deb
+RUN dpkg -i otelcol-contrib_0.128.0_linux_${ARCH}.deb
+
+COPY instrumentation/dist/*${ARCH}.deb injector.deb
+
+RUN dpkg -i injector.deb
+
+RUN echo /usr/lib/opentelemetry/libotelinject.so >> /etc/ld.so.preload
+
+COPY packaging/tests/shared/nodejs/app.js my_express_app/app.js
+COPY packaging/tests/shared/nodejs/test.sh test.sh
+
+CMD ["./test.sh"]

--- a/packaging/tests/deb/nodejs/run.sh
+++ b/packaging/tests/deb/nodejs/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+arch="${ARCH:-amd64}"
+if [ "$arch" = arm64 ]; then
+  docker_platform=linux/arm64
+elif [ "$arch" = amd64 ]; then
+  docker_platform=linux/amd64
+else
+  echo "The architecture $arch is not supported."
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+cd $SCRIPT_DIR/../../../..
+
+docker build \
+  --platform "$docker_platform" \
+  --build-arg "ARCH=$arch" \
+  -t "instrumentation-nodejs-$arch" \
+  -f packaging/tests/deb/nodejs/Dockerfile \
+  .
+docker run \
+  --platform "$docker_platform" \
+  --rm \
+  "instrumentation-nodejs-$arch"

--- a/packaging/tests/rpm/nodejs/Dockerfile
+++ b/packaging/tests/rpm/nodejs/Dockerfile
@@ -1,0 +1,31 @@
+FROM fedora:41
+
+ARG ARCH=amd64
+ARG RPM_ARCH=x86_64
+ARG tomcat_download_url
+
+ENV LANG=C.UTF-8
+
+RUN dnf -y update && \
+    dnf -y install nodejs npm wget && \
+    dnf clean all
+
+RUN mkdir my_express_app && \
+    cd my_express_app && \
+    npm init -y && \
+    npm install express --save
+
+# TODO The otel collector version needs to be kept up to date, potentially with renovate.
+RUN wget https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.128.0/otelcol-contrib_0.128.0_linux_${ARCH}.rpm
+RUN rpm -i otelcol-contrib_0.128.0_linux_${ARCH}.rpm
+
+COPY instrumentation/dist/*${RPM_ARCH}.rpm injector.rpm
+
+RUN rpm -i injector.rpm
+
+RUN echo /usr/lib/opentelemetry/libotelinject.so >> /etc/ld.so.preload
+
+COPY packaging/tests/shared/nodejs/app.js my_express_app/app.js
+COPY packaging/tests/shared/nodejs/test.sh test.sh
+
+CMD ["./test.sh"]

--- a/packaging/tests/rpm/nodejs/run.sh
+++ b/packaging/tests/rpm/nodejs/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -euo pipefail
+
+arch="${ARCH:-amd64}"
+if [ "$arch" = arm64 ]; then
+  docker_platform=linux/arm64
+elif [ "$arch" = amd64 ]; then
+  docker_platform=linux/amd64
+else
+  echo "The architecture $arch is not supported."
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd "$( dirname ${BASH_SOURCE[0]} )" && pwd )"
+cd $SCRIPT_DIR/../../../..
+
+docker build \
+  --platform "$docker_platform" \
+  --build-arg "ARCH=$arch" \
+  -t "instrumentation-nodejs-$arch" \
+  -f packaging/tests/rpm/nodejs/Dockerfile \
+  .
+docker run \
+  --platform "$docker_platform" \
+  --rm \
+  "instrumentation-nodejs-$arch"

--- a/packaging/tests/shared/nodejs/app.js
+++ b/packaging/tests/shared/nodejs/app.js
@@ -1,0 +1,11 @@
+const express = require('express')
+const app = express()
+const port = 3000
+
+app.get('/', (req, res) => {
+    res.send('Hello World!')
+});
+
+app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`)
+});

--- a/packaging/tests/shared/nodejs/test.sh
+++ b/packaging/tests/shared/nodejs/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+cd my_express_app
+node app.js &
+nodepid=$!
+loop=0
+
+function stop()
+{
+  kill $nodepid
+  loop=1
+  echo "Good bye"
+}
+
+function call()
+{
+  while [ $loop -eq 0 ]; do
+    wget -q http://localhost:3000
+    sleep 1
+  done
+}
+
+trap stop SIGINT
+
+call &
+
+# If the Express process is instrumented successfully, we should see a log report:
+# InstrumentationScope @opentelemetry/instrumentation-net in the collector's log output.
+expected_log_line="@opentelemetry/instrumentation-net"
+
+otelcol-contrib --config /etc/otelcol-contrib/config.yaml &> output.log &
+until (( count++ >= 5 ));
+do
+  grep "$expected_log_line" output.log && echo && echo "Test successful, the expected string \"$expected_log_line\" has been found in the collector's log output." && exit 0
+  sleep 4
+done
+
+echo
+echo "Test failed: The expected log \"$expected_log_line\" has not been found in the collector's log output."
+cat output.log
+exit 1


### PR DESCRIPTION
Testing identified issues with the RPM and Debian packages.
The Debian and RPM packages now contain the nodeJS dependencies organized in a folder structure rather than an archive.
The configuration points correctly to the file to load to launch autoinstrumentation.
  
NodeJS tests now run as part of CI.
