### PR TITLE
[chore] upgrade Zig to 0.15.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           # maintenance note: This version needs to be kept in sync with the version referenced in the file /zig-version
           # in the root of the repository.
-          version: 0.14.1
+          version: 0.15.2
 
       - name: lint source code
         run: |

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,7 +31,7 @@
 
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.14.1",
+    .minimum_zig_version = "0.15.2",
 
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.

--- a/src/args_parser.zig
+++ b/src/args_parser.zig
@@ -32,18 +32,18 @@ fn getCmdLineFromContent(allocator: std.mem.Allocator, content: []const u8) ![]c
     }
 
     // Split by null bytes to get arguments
-    var arg_list = std.ArrayList([]const u8).init(allocator);
-    errdefer arg_list.deinit();
+    var arg_list: std.ArrayList([]const u8) = .empty;
+    errdefer arg_list.deinit(allocator);
 
     var iter = std.mem.splitScalar(u8, content, 0);
     while (iter.next()) |arg| {
         if (arg.len > 0) { // Skip empty strings
             const arg_copy = try allocator.dupe(u8, arg);
-            try arg_list.append(arg_copy);
+            try arg_list.append(allocator, arg_copy);
         }
     }
 
-    const all_args = try arg_list.toOwnedSlice();
+    const all_args = try arg_list.toOwnedSlice(allocator);
 
     if (all_args.len == 0) {
         return error.NoCmdlineArgs;

--- a/src/node_js.zig
+++ b/src/node_js.zig
@@ -46,7 +46,7 @@ fn doCheckNodeJsAutoInstrumentationAgentAndGetModifiedNodeOptionsValue(
         }
         return null;
     };
-    const require_nodejs_auto_instrumentation_agent = std.fmt.allocPrintZ(alloc.page_allocator, "--require {s}", .{nodejs_auto_instrumentation_agent_path}) catch |err| {
+    const require_nodejs_auto_instrumentation_agent = std.fmt.allocPrintSentinel(alloc.page_allocator, "--require {s}", .{nodejs_auto_instrumentation_agent_path}, 0) catch |err| {
         print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ node_options_env_var_name, err });
         if (original_value_optional) |original_value| {
             return original_value;
@@ -85,7 +85,12 @@ fn getModifiedNodeOptionsValue(original_value_optional: ?[:0]const u8, require_n
         // If NODE_OPTIONS is already set, prepend the "--require ..." flag to the original value.
         // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
         // parent process.
-        const return_buffer = std.fmt.allocPrintZ(alloc.page_allocator, "{s} {s}", .{ require_nodejs_auto_instrumentation_agent, original_value }) catch |err| {
+        const return_buffer = std.fmt.allocPrintSentinel(
+            alloc.page_allocator,
+            "{s} {s}",
+            .{ require_nodejs_auto_instrumentation_agent, original_value },
+            0,
+        ) catch |err| {
             print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ node_options_env_var_name, err });
             return original_value;
         };

--- a/src/patterns_util.zig
+++ b/src/patterns_util.zig
@@ -7,8 +7,8 @@ const testing = std.testing;
 
 /// Splits a comma-separated string into a slice of trimmed strings.
 pub fn splitByComma(allocator: std.mem.Allocator, input: []const u8) ![][]const u8 {
-    var list: std.ArrayList([]const u8) = .init(allocator);
-    errdefer list.deinit();
+    var list: std.ArrayList([]const u8) = try .initCapacity(allocator, input.len);
+    errdefer list.deinit(allocator);
 
     var iter = std.mem.splitScalar(u8, input, ',');
     while (iter.next()) |item| {
@@ -18,11 +18,11 @@ pub fn splitByComma(allocator: std.mem.Allocator, input: []const u8) ![][]const 
                 print.printError("error allocating memory for path pattern from: {}", .{err});
                 return err;
             };
-            try list.append(owned);
+            try list.append(allocator, owned);
         }
     }
 
-    return list.toOwnedSlice();
+    return list.toOwnedSlice(allocator);
 }
 
 test "splitByComma: empty string" {

--- a/src/resource_attributes.zig
+++ b/src/resource_attributes.zig
@@ -75,7 +75,7 @@ pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]cons
             if (original_value.len == 0) {
                 // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
                 // parent process.
-                const return_buffer = std.fmt.allocPrintZ(alloc.page_allocator, "{s}", .{resource_attributes}) catch |err| {
+                const return_buffer = std.fmt.allocPrintSentinel(alloc.page_allocator, "{s}", .{resource_attributes}, 0) catch |err| {
                     print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ otel_resource_attributes_env_var_name, err });
                     return original_value;
                 };
@@ -86,7 +86,7 @@ pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]cons
             // Prepend our resource attributes to the already existing key-value pairs.
             // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
             // parent process.
-            const return_buffer = std.fmt.allocPrintZ(alloc.page_allocator, "{s},{s}", .{ resource_attributes, original_value }) catch |err| {
+            const return_buffer = std.fmt.allocPrintSentinel(alloc.page_allocator, "{s},{s}", .{ resource_attributes, original_value }, 0) catch |err| {
                 print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ otel_resource_attributes_env_var_name, err });
                 return original_value;
             };
@@ -95,7 +95,7 @@ pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]cons
         } else {
             // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
             // parent process.
-            const return_buffer = std.fmt.allocPrintZ(alloc.page_allocator, "{s}", .{resource_attributes}) catch |err| {
+            const return_buffer = std.fmt.allocPrintSentinel(alloc.page_allocator, "{s}", .{resource_attributes}, 0) catch |err| {
                 print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ otel_resource_attributes_env_var_name, err });
                 return null;
             };
@@ -107,7 +107,7 @@ pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]cons
         if (original_value_optional) |original_value| {
             // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
             // parent process.
-            const return_buffer = std.fmt.allocPrintZ(alloc.page_allocator, "{s}", .{original_value}) catch |err| {
+            const return_buffer = std.fmt.allocPrintSentinel(alloc.page_allocator, "{s}", .{original_value}, 0) catch |err| {
                 print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ otel_resource_attributes_env_var_name, err });
                 return original_value;
             };

--- a/src/root.zig
+++ b/src/root.zig
@@ -286,8 +286,8 @@ fn setCustomEnvVariables(custom_env_vars: std.StringHashMap([]u8)) bool {
     return true;
 }
 
-fn formatEnvVar(name: []const u8, value: []const u8) std.fmt.AllocPrintError![:0]u8 {
-    return std.fmt.allocPrintZ(alloc.page_allocator, "{s}={s}", .{ name, value });
+fn formatEnvVar(name: []const u8, value: []const u8) std.mem.Allocator.Error![:0]u8 {
+    return std.fmt.allocPrintSentinel(alloc.page_allocator, "{s}={s}", .{ name, value }, 0);
 }
 
 fn countEnvironmentVariables(environment: [*:null]?[*:0]u8) usize {

--- a/src/test_util.zig
+++ b/src/test_util.zig
@@ -35,10 +35,11 @@ pub fn setStdCEnviron(env_vars: []const []const u8) anyerror![*:null]?[*:0]u8 {
     // allocator.allocSentinel(?[*:0]u8, n, null).
     const new_environ = try test_allocator.allocSentinel(?[*:0]u8, env_vars.len, null);
     for (env_vars, 0..) |env_var, i| {
-        new_environ[i] = try std.fmt.allocPrintZ(
+        new_environ[i] = try std.fmt.allocPrintSentinel(
             test_allocator,
             "{s}",
             .{env_var},
+            0,
         );
     }
     std.c.environ = new_environ;

--- a/zig-version
+++ b/zig-version
@@ -1,3 +1,3 @@
 # See https://dl-cdn.alpinelinux.org/alpine/edge/community, check for zig-*.apk for available versions.
-# Keep this in sync with .github/workflows/ci.yaml -> mlugg/setup-zig.with.version.
-ZIG_VERSION=0.14.1-r0
+# Keep this in sync with .github/workflows/build.yaml -> mlugg/setup-zig.with.version.
+ZIG_VERSION=0.15.2-r0


### PR DESCRIPTION
### Reason for this PR

Zig 0.15.2 is the most recent stable version.
Update the codebase to use it.

### Details

* update managed ArrayList to unmanaged
* `allocPrintZ` changed to `allocPrintSentinel`
* use std.Io.Reader in `readConfigurationFile`

Bonus: add a `-Dtest-filter` option to build.zig to allow running unit tests with filters.

### Additional context

Running `make tests` is recommended but it's failing with a weird error on permissions 🤔 
```
Unable to find image 'libotelinject-builder:amd64' locally
docker: Error response from daemon: pull access denied for libotelinject-builder, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

I tried running  `make dist`, it seems the right one to build the image but on Linux apparently the local images aren't resolved 🤷🏼 

```
docker run -d --platform linux/amd64 --name libotelinject-builder libotelinject-builder:amd64 sleep inf
Unable to find image 'libotelinject-builder:amd64' locally
docker: Error response from daemon: pull access denied for libotelinject-builder, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```