### PR TITLE
chore(ci): skip entire changelog job for chores, dependencies etc.

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]') }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 
@@ -48,7 +48,6 @@ jobs:
           key: changelog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Ensure no changes to the CHANGELOG.md or CHANGELOG-API.md
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
           if [[ $(git diff --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./CHANGELOG*.md) ]]
           then
@@ -62,7 +61,6 @@ jobs:
           fi
 
       - name: Ensure ./.chloggen/*.yaml addition(s)
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |
           if [[ 1 -gt $(git diff --diff-filter=A --name-only $(git merge-base origin/main $PR_HEAD) $PR_HEAD ./.chloggen | grep -c \\.yaml) ]]
           then
@@ -82,10 +80,8 @@ jobs:
 
       # In order to validate any links in the yaml file, render the config to markdown
       - name: Render .chloggen changelog entries
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: make chlog-preview > changelog_preview.md
       - name: Link Checker
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         id: lychee
         uses: lycheeverse/lychee-action@a8c4c7cb88f0c7386610c35eb25108e448569cb0 # v2.7.0
         with:


### PR DESCRIPTION
Remove the if-condition from the individual steps and apply it to the job as a whole instead. This is in line with how it is handled in other OpenTelemetry repos, for example
https://github.com/open-telemetry/opentelemetry-collector/blob/v0.141.0/.github/workflows/changelog.yml#L24