### PR TITLE
chore: do not require square brackets to detect chores

### DIFF
--- a/.chloggen/TEMPLATE.yaml
+++ b/.chloggen/TEMPLATE.yaml
@@ -18,7 +18,7 @@ issues: []
 subtext:
 
 # If your change doesn't affect end users or the exported elements of any package,
-# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/.chloggen/add_exclude_include_paths_option.yaml
+++ b/.chloggen/add_exclude_include_paths_option.yaml
@@ -18,7 +18,7 @@ issues: [84]
 subtext: The change allows users to implement filters on what to instrument based on the executable name and the command line arguments
 
 # If your change doesn't affect end users or the exported elements of any package,
-# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/.chloggen/agent_env.yaml
+++ b/.chloggen/agent_env.yaml
@@ -23,7 +23,7 @@ subtext: |
   Injector will pass these variables to agents.
 
 # If your change doesn't affect end users or the exported elements of any package,
-# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/.chloggen/nodejs_testing.yaml
+++ b/.chloggen/nodejs_testing.yaml
@@ -23,7 +23,7 @@ subtext: |
   NodeJS tests now run as part of CI.
 
 # If your change doesn't affect end users or the exported elements of any package,
-# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/.chloggen/remove_systemd.yaml
+++ b/.chloggen/remove_systemd.yaml
@@ -19,7 +19,7 @@ subtext: |
   We can remove systemD instructions as the LD_PRELOAD solution works just as well and applies to any software.
 
 # If your change doesn't affect end users or the exported elements of any package,
-# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.
 # e.g. '[user]' or '[user, api]'
 # Include 'user' if the change is relevant to end users.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,7 @@
 # This action requires that any PR targeting the main branch should add a
 # yaml file to the ./.chloggen/ directory. If a CHANGELOG entry is not required,
-# or if performing maintance on the Changelog, add either \"[chore]\" to the title of
-# the pull request or add the \"Skip Changelog\" label to disable this action.
+# or if performing maintenance on the Changelog, add either "chore" to the title
+# of the pull request or add the \"Skip Changelog\" label to disable this action.
 
 name: changelog
 
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-24.04
-    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]') }}
+    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, 'chore') }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 
@@ -54,7 +54,7 @@ jobs:
             echo "CHANGELOG.md and CHANGELOG-API.md should not be directly modified."
             echo "Please add a .yaml file to the ./.chloggen/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
+            echo "Alternately, add either \"chore\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
             false
           else
             echo "CHANGELOG.md and CHANGELOG-API.md were not modified."
@@ -67,7 +67,7 @@ jobs:
             echo "No changelog entry was added to the ./.chloggen/ directory."
             echo "Please add a .yaml file to the ./.chloggen/ directory."
             echo "See CONTRIBUTING.md for more details."
-            echo "Alternately, add either \"[chore]\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
+            echo "Alternately, add either \"chore\" to the title of the pull request or add the \"Skip Changelog\" label if this job should be skipped."
             false
           else
             echo "A changelog entry was added to the ./.chloggen/ directory."

--- a/.github/workflows/scripts/prepare-release.sh
+++ b/.github/workflows/scripts/prepare-release.sh
@@ -23,7 +23,7 @@ git commit -m "changelog update ${CANDIDATE}"
 
 git push --set-upstream origin "${BRANCH}"
 
-gh pr create --head "$(git branch --show-current)" --title "[chore] Prepare release ${CANDIDATE}" --body "
+gh pr create --head "$(git branch --show-current)" --title "chore: prepare release ${CANDIDATE}" --body "
 The following commands were run to prepare this release:
 - make chlog-update VERSION=v${CANDIDATE}
 "

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Your pull-request should add a new `.yaml` file to this directory. The name of y
 
 During the collector release process, all `./.chloggen/*.yaml` files are transcribed into `CHANGELOG.md` and then deleted.
 
-If a changelog entry is not required, add either `[chore]` to the title of the pull request or add the `"Skip Changelog"` label to disable this action.
+If a changelog entry is not required, add either `chore` to the title of the pull request or add the `"Skip Changelog"` label to disable this action.
 
 **Recommended Steps**
 1. Create an entry file using `make chlog-new`. This generates a file based on your current branch (e.g. `./.chloggen/my-branch.yaml`)


### PR DESCRIPTION
Prefixing chore commits with "chore:" or "chore(scope):" is very common.
Even renovate (which we use in this repo) uses this pattern (example:
https://github.com/open-telemetry/opentelemetry-injector/commit/dd55d7c366023c29e4bb6a1681541a58e446f217)

The widely used conventional commit spec also uses that pattern:
https://www.conventionalcommits.org/en/v1.0.0/

On the other hand, using "[chore]" is much less common.

For that reason, we should detect chore commits without requiring square
brackets - even if that deviates from what other OpenTelemetry repos do.