### PR TITLE
chore: download zig instead of installing via apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,15 @@ FROM ${DOCKER_REPO}/alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b
 
 RUN apk add --no-cache make
 
-COPY zig-version /otel-injector-test-build/zig-version
-RUN source /otel-injector-test-build/zig-version && \
-  apk add zig="$ZIG_VERSION" --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community
+ARG ZIG_ARCHITECTURE
+
+RUN mkdir -p /opt/zig
+WORKDIR /opt/zig
+COPY zig-version .
+RUN . /opt/zig/zig-version && \
+  wget -q -O /tmp/zig.tar.gz https://ziglang.org/download/${ZIG_VERSION%-*}/zig-${ZIG_ARCHITECTURE}-linux-${ZIG_VERSION}.tar.xz && \
+  tar --strip-components=1 -xf /tmp/zig.tar.gz
+ENV PATH="$PATH:/opt/zig"
 
 WORKDIR /libotelinject
 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,14 @@ so/libotelinject.so: so
 
 .PHONY: dist
 dist:
+	@set -e
 	@mkdir -p dist
-	docker buildx build --platform linux/$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) -o type=image,name=libotelinject-builder:$(ARCH),push=false .
+	if [[ "$(ARCH)" = arm64 ]]; then \
+	  ZIG_ARCHITECTURE=aarch64; \
+	elif [[ "$(ARCH)" = amd64 ]]; then \
+	  ZIG_ARCHITECTURE=x86_64; \
+	fi; \
+	docker buildx build --platform linux/$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) --build-arg ZIG_ARCHITECTURE=$$ZIG_ARCHITECTURE -o type=image,name=libotelinject-builder:$(ARCH),push=false .
 	docker rm -f libotelinject-builder 2>/dev/null || true
 	docker run -d --platform linux/$(ARCH) --name libotelinject-builder libotelinject-builder:$(ARCH) sleep inf
 	docker exec libotelinject-builder make ARCH=$(ARCH) SHELL=/bin/sh all

--- a/devel.Dockerfile
+++ b/devel.Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /opt/zig
 WORKDIR /opt/zig
 COPY zig-version .
 RUN . /opt/zig/zig-version && \
-  wget -q -O /tmp/zig.tar.gz https://ziglang.org/download/${ZIG_VERSION%-*}/zig-${zig_architecture}-linux-${ZIG_VERSION%-*}.tar.xz && \
+  wget -q -O /tmp/zig.tar.gz https://ziglang.org/download/${ZIG_VERSION%-*}/zig-${zig_architecture}-linux-${ZIG_VERSION}.tar.xz && \
   tar --strip-components=1 -xf /tmp/zig.tar.gz
 ENV PATH="$PATH:/opt/zig"
 

--- a/zig-version
+++ b/zig-version
@@ -1,3 +1,3 @@
-# See https://dl-cdn.alpinelinux.org/alpine/edge/community, check for zig-*.apk for available versions.
+# See https://ziglang.org/download/ for available versions.
 # Keep this in sync with .github/workflows/build.yaml -> mlugg/setup-zig.with.version.
-ZIG_VERSION=0.15.2-r0
+ZIG_VERSION=0.15.2


### PR DESCRIPTION
This decouples the Alpine version used for building the injector binary from the Zig version.