### PR TITLE
Deinit InjectorConfiguration to prevent memory leak

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -67,6 +67,7 @@ export fn getenv(name_z: types.NullTerminatedString) ?types.NullTerminatedString
     print.printDebug("getenv({s}) called", .{name});
 
     const configuration = config.readConfiguration();
+    defer configuration.deinit();
 
     const res = getEnvValue(name, configuration);
 


### PR DESCRIPTION
Very new to zig, but I think #148 introduces a memory leak since `InjectorConfiguration` now includes a `HashMap` which needs to be freed when it goes out of scope.

https://github.com/open-telemetry/opentelemetry-injector/pull/148#discussion_r2627401235