### PR TITLE
fix(config): continue to read after overly long line

### DIFF
--- a/.chloggen/fix-config-reading.yaml
+++ b/.chloggen/fix-config-reading.yaml
@@ -1,0 +1,7 @@
+change_type: bug_fix
+component: config
+note: Fix handling of overly long lines in config file
+issues: [174]
+subtext: Continue to read the rest of the config file after discarding an overly long line
+change_logs: []
+


### PR DESCRIPTION
The update to Zig 0.15.2
(https://github.com/open-telemetry/opentelemetry-injector/pull/152) broke an edge case in the config parser: After encountering a overly long line, the config parser would stop reading the remaining lines of the config file, and instead of only ignoring the overly long line, would ignore the rest of the file.

While PR #152 tried to mitigate that by doubling the buffer size (and thus the problem only would occur on lines over 16k characters), it nevertheless only makes the bug more unlikely, but not impossible.

The better pattern to use here is to handle error.StreamTooLong inside the while-loop, so that the while-loop is not aborted by going into its else-branch.