### PR TITLE
chore: consistently pass allocator to functions that allocate memory

### DIFF
--- a/src/allocator.zig
+++ b/src/allocator.zig
@@ -1,6 +1,0 @@
-// Copyright The OpenTelemetry Authors
-// SPDX-License-Identifier: Apache-2.0
-
-const std = @import("std");
-
-pub const page_allocator: std.mem.Allocator = std.heap.page_allocator;

--- a/src/resource_attributes.zig
+++ b/src/resource_attributes.zig
@@ -3,7 +3,6 @@
 
 const std = @import("std");
 
-const alloc = @import("allocator.zig");
 const print = @import("print.zig");
 const types = @import("types.zig");
 
@@ -62,9 +61,9 @@ const mappings: [7]EnvToResourceAttributeMapping =
 
 /// Derive the modified value for OTEL_RESOURCE_ATTRIBUTES based on the original value, and on other resource attributes
 /// provided via the OTEL_INJECTOR_* environment variables.
-pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]const u8) !?types.NullTerminatedString {
-    var result_list = try std.ArrayList(u8).initCapacity(alloc.page_allocator, std.heap.pageSize());
-    const result_writer = result_list.writer(alloc.page_allocator);
+pub fn getModifiedOtelResourceAttributesValue(gpa: std.mem.Allocator, original_value_optional: ?[:0]const u8) !?types.NullTerminatedString {
+    var result_list = try std.ArrayList(u8).initCapacity(gpa, std.heap.pageSize());
+    const result_writer = result_list.writer(gpa);
 
     // Key-value pairs from the original environment variable value have the highest priority. We write them first, and
     // then later, when processing OTEL_INJECTOR_RESOURCE_ATTRIBUTES or any of the mappings, we check for each key if
@@ -180,13 +179,13 @@ pub fn getModifiedOtelResourceAttributesValue(original_value_optional: ?[:0]cons
     }
 
     if (!has_modified_value) {
-        result_list.deinit(alloc.page_allocator);
+        result_list.deinit(gpa);
         return null;
     }
 
     try result_writer.writeAll("\x00");
 
-    const result_owned = try result_list.toOwnedSlice(alloc.page_allocator);
+    const result_owned = try result_list.toOwnedSlice(gpa);
     const result_as_null_terminated_string: types.NullTerminatedString = @ptrCast(result_owned.ptr);
 
     return result_as_null_terminated_string;

--- a/src/resource_attributes_test.zig
+++ b/src/resource_attributes_test.zig
@@ -3,7 +3,6 @@
 
 const std = @import("std");
 
-const alloc = @import("allocator.zig");
 const res_attrs = @import("resource_attributes.zig");
 const test_util = @import("test_util.zig");
 
@@ -15,77 +14,87 @@ const testing = std.testing;
 // risk of even compiling the test mechanism to modify the environment.
 
 test "getModifiedOtelResourceAttributesValue: no original value, no new resource attributes (null)" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null);
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null);
     try test_util.expectWithMessage(modified_value == null, "modified_value == null");
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value, no new resource attributes (empty string)" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("");
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "");
     try test_util.expectWithMessage(modified_value == null, "modified_value == null");
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: namespace only" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace"});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.namespace.name=namespace", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: pod name only" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_POD_NAME=pod"});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.pod.name=pod", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: pod uid only" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_POD_UID=uid"});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.pod.uid=uid", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: container name only" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_CONTAINER_NAME=container"});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.container.name=container", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: OTEL_INJECTOR_RESOURCE_ATTRIBUTES only" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_RESOURCE_ATTRIBUTES=aaa=bbb,ccc=ddd"});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("aaa=bbb,ccc=ddd", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), several new resource attributes" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
         "OTEL_INJECTOR_K8S_POD_UID=uid",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (empty string), several new resource attributes" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
         "OTEL_INJECTOR_K8S_POD_UID=uid",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("") orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "") orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: everything is set" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
@@ -97,7 +106,7 @@ test "getModifiedOtelResourceAttributesValue: no original value (null), new reso
         "OTEL_INJECTOR_RESOURCE_ATTRIBUTES=aaa=bbb,ccc=ddd",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings(
         "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid,k8s.container.name=container,service.name=service,service.version=version,service.namespace=servicenamespace",
         std.mem.span(modified_value),
@@ -105,24 +114,27 @@ test "getModifiedOtelResourceAttributesValue: no original value (null), new reso
 }
 
 test "getModifiedOtelResourceAttributesValue: original value exists, no new resource attributes" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("aaa=bbb,ccc=ddd");
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd");
     try test_util.expectWithMessage(modified_value == null, "modified_value == null");
 }
 
 test "getModifiedOtelResourceAttributesValue: original value and new resource attributes" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
         "OTEL_INJECTOR_K8S_POD_UID=uid",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("aaa=bbb,ccc=ddd") orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd") orelse return error.Unexpected;
     try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: key-value pairs in original value have higher precedence than OTEL_INJECTOR_*" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[7][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-otel-injector",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-otel-injector",
@@ -133,20 +145,22 @@ test "getModifiedOtelResourceAttributesValue: key-value pairs in original value 
         "OTEL_INJECTOR_SERVICE_NAMESPACE=servicenamespace-otel-injector",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
     try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: key-value pairs in original value have higher precedence than OTEL_INJECTOR_RESOURCE_ATTRIBUTES" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{
         "OTEL_INJECTOR_RESOURCE_ATTRIBUTES=k8s.namespace.name=namespace-otel-injector,k8s.pod.name=pod-otel-injector,service.name=service-otel-injector,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
     try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: OTEL_INJECTOR_RESOURCE_ATTRIBUTES key-value pairs have higher precedence than other OTEL_INJECTOR_* attributes" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-from-otel-injector_*-env-var",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-from-otel-injector_*-env-var",
@@ -158,11 +172,12 @@ test "getModifiedOtelResourceAttributesValue: OTEL_INJECTOR_RESOURCE_ATTRIBUTES 
         "OTEL_INJECTOR_SERVICE_NAMESPACE=servicenamespace-from-otel-injector_*-env-var",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.namespace.name=namespace-from-otel-injector-resource-attributes,k8s.pod.name=pod-from-otel-injector-resource-attributes,service.name=service-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector-resource-attributes,k8s.container.name=container-from-otel-injector-resource-attributes,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: mixing key-value pairs from the original value, OTEL_INJECTOR_RESOURCE_ATTRIBUTES and OTEL_INJECTOR_*" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-from-otel-injector_*-env-var",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-from-otel-injector_*-env-var",
@@ -174,13 +189,14 @@ test "getModifiedOtelResourceAttributesValue: mixing key-value pairs from the or
         "OTEL_INJECTOR_SERVICE_NAMESPACE=servicenamespace-from-otel-injector_*-env-var",
     });
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue("k8s.namespace.name=namespace-original,service.name=service-original") orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "k8s.namespace.name=namespace-original,service.name=service-original") orelse return error.Unexpected;
     try testing.expectEqualStrings("k8s.namespace.name=namespace-original,service.name=service-original,k8s.pod.name=pod-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector_*-env-var,k8s.container.name=container-from-otel-injector_*-env-var,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var", std.mem.span(modified_value));
 }
 
 test "getModifiedOtelResourceAttributesValue: trims keys and drops empty OTEL_INJECTOR_RESOURCE_ATTRIBUTES key-value pairs" {
+    const allocator = std.heap.page_allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_RESOURCE_ATTRIBUTES=aaa=bbb,,  ccc=ddd,  , eee = fff "});
     defer test_util.resetStdCEnviron(original_environ);
-    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(null) orelse return error.Unexpected;
+    const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
     try testing.expectEqualStrings("aaa=bbb,ccc=ddd,eee= fff ", std.mem.span(modified_value));
 }


### PR DESCRIPTION
Previously, the code mostly referenced one globally declared page allocator (src/alloc.zig#page_allocator) directly, whenever it needed to allocate memory.

This change moves to a more idiomatic pattern, where calling code (e.g. src/root.zig) passes down an allocator into the functions requiring one.

In production code, we now only declare one allocator at the start of initEnviron. This is passed to all other functions that need an allocator. This also makes it much more obvious which functions allocate memory and which functions are allocation free.

Ultimately, all unit tests should probably use std.testing.allocator and free everything they allocated, this is not in scope for this change (a lot of test code still uses std.heap.page_allocator directly).

Fixes #178.