### PR TITLE
chore: use sentinel-terminated slices internally

### DIFF
--- a/src/jvm.zig
+++ b/src/jvm.zig
@@ -5,7 +5,6 @@ const std = @import("std");
 
 const config = @import("config.zig");
 const print = @import("print.zig");
-const res_attrs = @import("resource_attributes.zig");
 const types = @import("types.zig");
 const test_util = @import("test_util.zig");
 
@@ -13,11 +12,16 @@ const testing = std.testing;
 
 pub const java_tool_options_env_var_name = "JAVA_TOOL_OPTIONS";
 
+/// Returns the modified value for JAVA_TOOL_OPTIONS, including the -javaagent flag; based on the original value of
+/// JAVA_TOOL_OPTIONS.
+///
+/// The caller is responsible for freeing the returned string (unless the result is passed on to setenv and needs to
+/// stay in memory).
 pub fn checkOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
     gpa: std.mem.Allocator,
     original_value_optional: ?[:0]const u8,
     configuration: config.InjectorConfiguration,
-) ?types.NullTerminatedString {
+) ?[:0]u8 {
     return doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
         gpa,
         original_value_optional,
@@ -29,7 +33,7 @@ fn doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
     gpa: std.mem.Allocator,
     original_value_optional: ?[:0]const u8,
     jvm_auto_instrumentation_agent_path: []u8,
-) ?types.NullTerminatedString {
+) ?[:0]u8 {
     if (jvm_auto_instrumentation_agent_path.len == 0) {
         print.printInfo("Skipping the injection of the OpenTelemetry Java agent in \"JAVA_TOOL_OPTIONS\" because it has been explicitly disabled.", .{});
         return null;
@@ -57,95 +61,114 @@ fn doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
 test "doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue: should return null if the Java agent cannot be accessed (original value not set)" {
     const path = try std.fmt.allocPrint(testing.allocator, "/invalid/path", .{});
     defer testing.allocator.free(path);
-    const modifiedJavaToolOptions =
+    const modified_java_tool_options =
         doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
-            std.heap.page_allocator,
+            testing.allocator,
             null,
             path,
         );
-    try test_util.expectWithMessage(modifiedJavaToolOptions == null, "modifiedJavaToolOptions == null");
+    try test_util.expectWithMessage(modified_java_tool_options == null, "modified_java_tool_options == null");
 }
 
 test "doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue: should return null if the Java agent cannot be accessed (original value present)" {
     const path = try std.fmt.allocPrint(testing.allocator, "/invalid/path", .{});
     defer testing.allocator.free(path);
-    const modifiedJavaToolOptions =
+    const modified_java_tool_options =
         doCheckOTelJavaAgentJarAndGetModifiedJavaToolOptionsValue(
-            std.heap.page_allocator,
+            testing.allocator,
             "original value",
             path,
         );
-    try test_util.expectWithMessage(modifiedJavaToolOptions == null, "modifiedJavaToolOptions == null");
+    try test_util.expectWithMessage(modified_java_tool_options == null, "modified_java_tool_options == null");
 }
 
-/// Returns the modified value for JAVA_TOOL_OPTIONS, including the -javaagent flag; based on the original value of
-/// JAVA_TOOL_OPTIONS.
-///
-/// Do no deallocate the return value, or we may cause a USE_AFTER_FREE memory corruption in the parent process.
 fn getModifiedJavaToolOptionsValue(
     gpa: std.mem.Allocator,
     original_java_tool_options_env_var_value_optional: ?[:0]const u8,
-    javaagent_flag_value: types.NullTerminatedString,
-) ?types.NullTerminatedString {
+    javaagent_flag_value: [:0]u8,
+) ?[:0]u8 {
     // For auto-instrumentation, we inject the -javaagent flag into the JAVA_TOOL_OPTIONS environment variable.
     if (original_java_tool_options_env_var_value_optional) |original_java_tool_options_env_var_value| {
-        if (std.mem.indexOf(u8, original_java_tool_options_env_var_value, std.mem.span(javaagent_flag_value))) |_| {
+        if (std.mem.indexOf(u8, original_java_tool_options_env_var_value, javaagent_flag_value)) |_| {
             // If our "-javaagent ..." flag is already present in JAVA_TOOL_OPTIONS, do nothing. This is particularly
             // important to avoid double injection, for example if we are injecting into a container which has a shell
             // executable as its entry point (into which we inject env var modifications), and then this shell starts
             // the JVM executable as a child process, which inherits the environment from the already injected shell.
+            gpa.free(javaagent_flag_value);
             return null;
         }
 
         // If JAVA_TOOL_OPTIONS is already set, prepend the "-javaagent ..." flag to the original value.
-        // Note: We must never free the return_buffer, or we may cause a USE_AFTER_FREE memory corruption in the
-        // parent process.
-        const return_buffer =
-            std.fmt.allocPrintSentinel(gpa, "{s} {s}", .{
-                original_java_tool_options_env_var_value,
-                javaagent_flag_value,
-            }, 0) catch |err| {
-                print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ java_tool_options_env_var_name, err });
-                return null;
-            };
-        return return_buffer.ptr;
-    } else {
-        // JAVA_TOOL_OPTIONS is not set, simply return the -javaagent flag.
-        return javaagent_flag_value[0..];
+        // Since we copy over javaagent_flag_value into newly allocated memory, we can free the parameter here.
+        defer gpa.free(javaagent_flag_value);
+        return std.fmt.allocPrintSentinel(gpa, "{s} {s}", .{
+            original_java_tool_options_env_var_value,
+            javaagent_flag_value,
+        }, 0) catch |err| {
+            print.printError("Cannot allocate memory to manipulate the value of \"{s}\": {}", .{ java_tool_options_env_var_name, err });
+            return null;
+        };
     }
+
+    // JAVA_TOOL_OPTIONS is not set, simply return the -javaagent flag.
+    return javaagent_flag_value[0..];
 }
 
 test "getModifiedJavaToolOptionsValue: should return -javaagent if original value is unset" {
-    const modifiedJavaToolOptions = getModifiedJavaToolOptionsValue(
-        std.heap.page_allocator,
-        null,
+    const javaagent_flag_value = try std.fmt.allocPrintSentinel(
+        testing.allocator,
         "-javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar",
+        .{},
+        0,
     );
+    const modified_java_tool_options = getModifiedJavaToolOptionsValue(
+        testing.allocator,
+        null,
+        javaagent_flag_value,
+    );
+    defer (if (modified_java_tool_options) |val| {
+        testing.allocator.free(val);
+    });
     try testing.expectEqualStrings(
         "-javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar",
-        std.mem.span(modifiedJavaToolOptions orelse "-"),
+        modified_java_tool_options orelse "-",
     );
 }
 
 test "getModifiedJavaToolOptionsValue: should append -javaagent if original value exists" {
     const original_value: [:0]const u8 = "-Dsome.property=value"[0.. :0];
-    const modifiedJavaToolOptions = getModifiedJavaToolOptionsValue(
-        std.heap.page_allocator,
-        original_value,
+    const javaagent_flag_value = try std.fmt.allocPrintSentinel(
+        testing.allocator,
         "-javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar",
+        .{},
+        0,
     );
+    const modified_java_tool_options = getModifiedJavaToolOptionsValue(
+        testing.allocator,
+        original_value,
+        javaagent_flag_value,
+    );
+    defer (if (modified_java_tool_options) |val| {
+        testing.allocator.free(val);
+    });
     try testing.expectEqualStrings(
         "-Dsome.property=value -javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar",
-        std.mem.span(modifiedJavaToolOptions orelse "-"),
+        modified_java_tool_options orelse "-",
     );
 }
 
 test "getModifiedJavaToolOptionsValue: should do nothing if our -javaagent is already present" {
     const original_value: [:0]const u8 = "-Dsome.property=value -javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar -Dsome.other.property=value"[0.. :0];
-    const modifiedJavaToolOptions = getModifiedJavaToolOptionsValue(
-        std.heap.page_allocator,
-        original_value,
+    const javaagent_flag_value = try std.fmt.allocPrintSentinel(
+        testing.allocator,
         "-javaagent:/__otel_auto_instrumentation/jvm/opentelemetry-javaagent.jar",
+        .{},
+        0,
     );
-    try test_util.expectWithMessage(modifiedJavaToolOptions == null, "modifiedJavaToolOptions == null");
+    const modified_java_tool_options = getModifiedJavaToolOptionsValue(
+        testing.allocator,
+        original_value,
+        javaagent_flag_value,
+    );
+    try test_util.expectWithMessage(modified_java_tool_options == null, "modified_java_tool_options == null");
 }

--- a/src/print.zig
+++ b/src/print.zig
@@ -99,7 +99,7 @@ fn takeSentinelOrDiscardOverlyLongLine(reader: *std.fs.File.Reader) ![:0]u8 {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL is not set" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-no-log-level" });
@@ -111,7 +111,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL is not set" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=debug" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-debug" });
@@ -122,7 +122,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=debug" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=info" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-info" });
@@ -133,7 +133,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=info" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=warn" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-warn" });
@@ -144,7 +144,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=warn" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=error" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-error" });
@@ -155,7 +155,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=error" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=none" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-none" });
@@ -166,7 +166,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=none" {
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=none with overly long environment variable" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-none-overly-long-env-var" });
@@ -177,7 +177,7 @@ test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL=none with overly long environment va
 
 test "initLogLevel: OTEL_INJECTOR_LOG_LEVEL is an arbitrary string" {
     defer resetLogLevel();
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
     defer allocator.free(cwd_path);
     const absolute_path_to_environ_file = try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/proc-self-environ/environ-log-level-arbitrary-string" });

--- a/src/resource_attributes_test.zig
+++ b/src/resource_attributes_test.zig
@@ -14,7 +14,7 @@ const testing = std.testing;
 // risk of even compiling the test mechanism to modify the environment.
 
 test "getModifiedOtelResourceAttributesValue: no original value, no new resource attributes (null)" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null);
@@ -22,7 +22,7 @@ test "getModifiedOtelResourceAttributesValue: no original value, no new resource
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value, no new resource attributes (empty string)" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "");
@@ -30,47 +30,52 @@ test "getModifiedOtelResourceAttributesValue: no original value, no new resource
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: namespace only" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace"});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.namespace.name=namespace", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.namespace.name=namespace", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: pod name only" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_POD_NAME=pod"});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.pod.name=pod", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.pod.name=pod", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: pod uid only" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_POD_UID=uid"});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.pod.uid=uid", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.pod.uid=uid", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: container name only" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_K8S_CONTAINER_NAME=container"});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.container.name=container", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.container.name=container", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: OTEL_INJECTOR_RESOURCE_ATTRIBUTES only" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_RESOURCE_ATTRIBUTES=aaa=bbb,ccc=ddd"});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("aaa=bbb,ccc=ddd", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("aaa=bbb,ccc=ddd", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), several new resource attributes" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
@@ -78,11 +83,12 @@ test "getModifiedOtelResourceAttributesValue: no original value (null), several 
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (empty string), several new resource attributes" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
@@ -90,11 +96,12 @@ test "getModifiedOtelResourceAttributesValue: no original value (empty string), 
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "") orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", modified_value);
 }
 
 test "getModifiedOtelResourceAttributesValue: no original value (null), new resource attributes: everything is set" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
@@ -107,14 +114,15 @@ test "getModifiedOtelResourceAttributesValue: no original value (null), new reso
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
+    defer allocator.free(modified_value);
     try testing.expectEqualStrings(
         "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid,k8s.container.name=container,service.name=service,service.version=version,service.namespace=servicenamespace",
-        std.mem.span(modified_value),
+        modified_value,
     );
 }
 
 test "getModifiedOtelResourceAttributesValue: original value exists, no new resource attributes" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd");
@@ -122,7 +130,7 @@ test "getModifiedOtelResourceAttributesValue: original value exists, no new reso
 }
 
 test "getModifiedOtelResourceAttributesValue: original value and new resource attributes" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[3][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace",
         "OTEL_INJECTOR_K8S_POD_NAME=pod",
@@ -130,11 +138,15 @@ test "getModifiedOtelResourceAttributesValue: original value and new resource at
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd") orelse return error.Unexpected;
-    try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings(
+        "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace,k8s.pod.name=pod,k8s.pod.uid=uid",
+        modified_value,
+    );
 }
 
 test "getModifiedOtelResourceAttributesValue: key-value pairs in original value have higher precedence than OTEL_INJECTOR_*" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[7][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-otel-injector",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-otel-injector",
@@ -146,21 +158,29 @@ test "getModifiedOtelResourceAttributesValue: key-value pairs in original value 
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
-    try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings(
+        "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector",
+        modified_value,
+    );
 }
 
 test "getModifiedOtelResourceAttributesValue: key-value pairs in original value have higher precedence than OTEL_INJECTOR_RESOURCE_ATTRIBUTES" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{
         "OTEL_INJECTOR_RESOURCE_ATTRIBUTES=k8s.namespace.name=namespace-otel-injector,k8s.pod.name=pod-otel-injector,service.name=service-otel-injector,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector",
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original") orelse return error.Unexpected;
-    try testing.expectEqualStrings("aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings(
+        "aaa=bbb,ccc=ddd,k8s.namespace.name=namespace-original,k8s.pod.name=pod-original,service.name=service-original,service.version=version-original,service.namespace=servicenamespace-original,k8s.pod.uid=uid-otel-injector,k8s.container.name=container-otel-injector",
+        modified_value,
+    );
 }
 
 test "getModifiedOtelResourceAttributesValue: OTEL_INJECTOR_RESOURCE_ATTRIBUTES key-value pairs have higher precedence than other OTEL_INJECTOR_* attributes" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-from-otel-injector_*-env-var",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-from-otel-injector_*-env-var",
@@ -173,11 +193,15 @@ test "getModifiedOtelResourceAttributesValue: OTEL_INJECTOR_RESOURCE_ATTRIBUTES 
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.namespace.name=namespace-from-otel-injector-resource-attributes,k8s.pod.name=pod-from-otel-injector-resource-attributes,service.name=service-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector-resource-attributes,k8s.container.name=container-from-otel-injector-resource-attributes,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings(
+        "k8s.namespace.name=namespace-from-otel-injector-resource-attributes,k8s.pod.name=pod-from-otel-injector-resource-attributes,service.name=service-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector-resource-attributes,k8s.container.name=container-from-otel-injector-resource-attributes,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var",
+        modified_value,
+    );
 }
 
 test "getModifiedOtelResourceAttributesValue: mixing key-value pairs from the original value, OTEL_INJECTOR_RESOURCE_ATTRIBUTES and OTEL_INJECTOR_*" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
         "OTEL_INJECTOR_K8S_NAMESPACE_NAME=namespace-from-otel-injector_*-env-var",
         "OTEL_INJECTOR_K8S_POD_NAME=pod-from-otel-injector_*-env-var",
@@ -190,13 +214,18 @@ test "getModifiedOtelResourceAttributesValue: mixing key-value pairs from the or
     });
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, "k8s.namespace.name=namespace-original,service.name=service-original") orelse return error.Unexpected;
-    try testing.expectEqualStrings("k8s.namespace.name=namespace-original,service.name=service-original,k8s.pod.name=pod-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector_*-env-var,k8s.container.name=container-from-otel-injector_*-env-var,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings(
+        "k8s.namespace.name=namespace-original,service.name=service-original,k8s.pod.name=pod-from-otel-injector-resource-attributes,k8s.pod.uid=uid-from-otel-injector_*-env-var,k8s.container.name=container-from-otel-injector_*-env-var,service.version=version-from-otel-injector_*-env-var,service.namespace=servicenamespace-from-otel-injector_*-env-var",
+        modified_value,
+    );
 }
 
 test "getModifiedOtelResourceAttributesValue: trims keys and drops empty OTEL_INJECTOR_RESOURCE_ATTRIBUTES key-value pairs" {
-    const allocator = std.heap.page_allocator;
+    const allocator = testing.allocator;
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{"OTEL_INJECTOR_RESOURCE_ATTRIBUTES=aaa=bbb,,  ccc=ddd,  , eee = fff "});
     defer test_util.resetStdCEnviron(original_environ);
     const modified_value = try res_attrs.getModifiedOtelResourceAttributesValue(allocator, null) orelse return error.Unexpected;
-    try testing.expectEqualStrings("aaa=bbb,ccc=ddd,eee= fff ", std.mem.span(modified_value));
+    defer allocator.free(modified_value);
+    try testing.expectEqualStrings("aaa=bbb,ccc=ddd,eee= fff ", modified_value);
 }

--- a/src/types.zig
+++ b/src/types.zig
@@ -1,11 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-pub const NullTerminatedString = [*:0]const u8;
+pub const DlSymFn = *const fn (handle: ?*anyopaque, symbol: [*:0]const u8) ?*anyopaque;
 
-pub const DlSymFn = *const fn (handle: ?*anyopaque, symbol: NullTerminatedString) ?*anyopaque;
-
-pub const SetenvFnPtr = *const fn (name: NullTerminatedString, value: NullTerminatedString, overwrite: bool) c_int;
+pub const SetenvFnPtr = *const fn (name: [*:0]const u8, value: [*:0]const u8, overwrite: bool) c_int;
 
 pub const EnvironPtr = *[*c][*c]const u8;
 


### PR DESCRIPTION
Use sentinel-terminated slices
(https://ziglang.org/documentation/0.15.2/#Sentinel-Terminated-Slices)
internally for all strings, instead of the more clumsy
sentinel-terminated many-pointers
(https://ziglang.org/documentation/0.15.2/#Sentinel-Terminated-Pointers).

Convert the sentinel-terminated slices to sentinel-terminated
many-pointers at the last possible moment, when calling setenv.
We can also get rid of the explicit @ptrCast(xxx.ptr), since
sentinel-terminated slices can be coerced to sentinel-terminated
many-pointers.

This allows to more easily free the produced slices in unit tests, which
in turn enables using std.testing.allocator, which in turn helps to uncover
memory leaks.

As a result, this commit also adds a couple of allocator.free calls to
production code to fix some minor leaks that were uncovered because of
this (e.g. preliminary strings that are later copied over to another
memory region and can then be discarded).

This is most of the work required to fix #181, but two usage patterns
with std.heap.page_allocator in unit tests remain for now, in
config.zig, and in resource_attributes_test.zig.