### PR TITLE
chore: use arena allocator for intermediate values in config.zig

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -64,7 +64,8 @@ fn initEnviron() callconv(.c) void {
         return;
     };
 
-    const configuration = config.readConfiguration(allocator);
+    var configuration = config.readConfiguration(allocator);
+    defer configuration.deinit(allocator);
 
     if (!evaluateAllowDeny(allocator, configuration)) {
         return;
@@ -347,10 +348,10 @@ fn setCustomEnvironmentVariables(
     while (env_var_iterator.next()) |env_var| {
         const name = allocator.dupeZ(u8, env_var.key_ptr.*) catch |err| {
             print.printError(
-                "error allocating memory for name when setting custom environment variable \"{}\"=\"{}\" (remaining custom environment variables will be skipped) : {}",
+                "error allocating memory for name when setting custom environment variable \"{s}\"=\"{s}\" (remaining custom environment variables will be skipped): {}",
                 .{
-                    env_var.key_ptr,
-                    env_var.value_ptr,
+                    env_var.key_ptr.*,
+                    env_var.value_ptr.*,
                     err,
                 },
             );
@@ -358,10 +359,10 @@ fn setCustomEnvironmentVariables(
         };
         const value = allocator.dupeZ(u8, env_var.value_ptr.*) catch |err| {
             print.printError(
-                "error allocating memory for value when setting custom environment variable \"{}\"=\"{}\" (remaining custom environment variables will be skipped): {}",
+                "error allocating memory for value when setting custom environment variable \"{s}\"=\"{s}\" (remaining custom environment variables will be skipped): {}",
                 .{
-                    env_var.key_ptr,
-                    env_var.value_ptr,
+                    env_var.key_ptr.*,
+                    env_var.value_ptr.*,
                     err,
                 },
             );

--- a/test/README.md
+++ b/test/README.md
@@ -27,8 +27,9 @@ Usage
   whose names _contain_ one of the provided strings as a substring.
   The test cases are listed in the different `scripts/*.tests` files.
   Can be combined with `ARCHITECTURES`, `LIBC_FLAVORS` etc., cannot be combined with `TEST_CASES`.
-* Set `VERBOSE=true` to always include the output from running the test case. Otherwise, the output is only
-  printed to stdout when a test case fails.
+* Set `VERBOSE=true` to set `OTEL_INJECTOR_LOG_LEVEL=debug` when running test cases and to always include the output
+  from running the test case. Otherwise, the default log level (`error`) is used, and output is only printed to stdout
+  when a test case fails.
 * Set `INTERACTIVE=true` to get a shell into the container under test, instead of running a test. Best used when working
   on a test for one specific runtime, you would usually want to combine this with something like
   `ARCHITECTURES=arm64 LIBC_FLAVORS=glibc TEST_SETS=dotnet INTERACTIVE=true scripts/test-all.sh` to narrow down the

--- a/unit-test-assets/config/all_values.conf
+++ b/unit-test-assets/config/all_values.conf
@@ -1,7 +1,7 @@
-all_auto_instrumentation_agents_env_path=/custom/path/to/auto_instrumentation_env.conf
 dotnet_auto_instrumentation_agent_path_prefix=/custom/path/to/dotnet/instrumentation
 jvm_auto_instrumentation_agent_path=/custom/path/to/jvm/opentelemetry-javaagent.jar
 nodejs_auto_instrumentation_agent_path=/custom/path/to/node_js/node_modules/@opentelemetry-js/otel/instrument
+all_auto_instrumentation_agents_env_path=/custom/path/to/auto_instrumentation_env.conf
 include_paths=/app/*,/home/user/test/*
 include_paths=/another_dir/*
 exclude_paths=/usr/*,/opt/*


### PR DESCRIPTION
Using std.testing.allocator consistently in all unit tests for config
parsing revealed that src/config.zig previously leaked memory for a
couple of intermediate values. For example default values for config
settings that go out of scope when they are replaced with the actual
configured value from the config file or from environment variables, but
also allocated strings that are handled during parsing.

While it is certainly possible to get rid of those by carefully
sprinkling allocator.free calls all over the code, this approach is
error-prone and will also incur high maintenance effort down the road.

Using an arena allocator for the intermediate values and freeing them
all at once when the parsing is done is more robust.

Fixes #182

Fixes #181, for src/config.zig (181 is fixed entirely assuming #183 is also merged).