### PR TITLE
feat(config): add OTEL_INJECTOR_CONFIG_FILE to set config file location

### DIFF
--- a/.chloggen/make-path-to-config-file-configurable.yaml
+++ b/.chloggen/make-path-to-config-file-configurable.yaml
@@ -1,0 +1,19 @@
+change_type: enhancement
+
+component: config
+
+note: add OTEL_INJECTOR_CONFIG_FILE to set config file location
+
+issues: [188]
+
+subtext: |
+  This adds support for a new environment variable `OTEL_INJECTOR_CONFIG_FILE` that determines from which path the
+  injector's configuration file is read. If the variable is not set or empty, the configuration file is read from the
+  default path `/etc/opentelemetry/otelinject.conf`.
+
+  This is useful in environments where you want to provide a configuration file, but you do not want to make any
+  assumptions about the underlying file system's structure. I.e. you want to keep all assets of the injector (injector
+  binary, auto-instrumentation agents and the injector configuration) completely separate from standard OS directories
+  like `/etc`.
+
+change_logs: []

--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ This method requires `root` privileges.
    jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/javaagent.jar
    nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/otel-js/node_modules/@opentelemetry-js/otel/instrument
    ```
+
+   You can override the location of the configuration file by setting `OTEL_INJECTOR_CONFIG_FILE`.
+
    You may want to modify this file for a couple of reasons:
    - You want to provide your own instrumentation files.
 
    - You want to selectively disable auto-instrumentation for a specific runtime, by setting the respective path
-     to an empty string in the configuration file `/etc/opentelemetry/otelinject.conf`.
+     to an empty string in the configuration file.
      For example, the following file would leave JVM and Node.js auto-instrumentation active, while disabling .NET
      auto-instrumentation:
       ```
@@ -68,7 +71,7 @@ This method requires `root` privileges.
      to programs that do not contain certain arguments on the command line.
      See [details on configuring the program inclusion and exclusion criteria](#details-on-configuring-the-program-inclusion-and-exclusion-criteria) for more information.
 
-   The values set in `/etc/opentelemetry/otelinject.conf` can be overridden with environment variables.
+   The values set in the configuration file can be overridden with environment variables.
    (This should usually not be necessary.)
    - `DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX`: the path to the directory containing the .NET auto-instrumentation
      agent files

--- a/test/docker/Dockerfile-dotnet
+++ b/test/docker/Dockerfile-dotnet
@@ -43,6 +43,7 @@ COPY test/scripts/run-tests-within-container.sh scripts/
 COPY test/scripts/create-*.sh scripts/
 COPY test/scripts/*.tests scripts/
 COPY test/docker/otelinject.conf otelinject.conf
+COPY test/docker/otelinject.custom-location.conf /custom/config/path/otelinject.conf
 COPY test/docker/default_auto_instrumentation_env.conf default_auto_instrumentation_env.conf
 
 RUN ${create_sdk_dummy_files_script}

--- a/test/docker/Dockerfile-jvm
+++ b/test/docker/Dockerfile-jvm
@@ -33,6 +33,7 @@ COPY test/scripts/run-tests-within-container.sh scripts/
 COPY test/scripts/create-*.sh scripts/
 COPY test/scripts/*.tests scripts/
 COPY test/docker/otelinject.conf otelinject.conf
+COPY test/docker/otelinject.custom-location.conf /custom/config/path/otelinject.conf
 COPY test/docker/default_auto_instrumentation_env.conf default_auto_instrumentation_env.conf
 
 RUN ${create_sdk_dummy_files_script}

--- a/test/docker/Dockerfile-node_js
+++ b/test/docker/Dockerfile-node_js
@@ -26,6 +26,7 @@ COPY test/scripts/run-tests-within-container.sh scripts/
 COPY test/scripts/create-*.sh scripts/
 COPY test/scripts/*.tests scripts/
 COPY test/docker/otelinject.conf otelinject.conf
+COPY test/docker/otelinject.custom-location.conf /custom/config/path/otelinject.conf
 COPY test/docker/default_auto_instrumentation_env.conf default_auto_instrumentation_env.conf
 
 RUN ${create_sdk_dummy_files_script}

--- a/test/docker/otelinject.custom-location.conf
+++ b/test/docker/otelinject.custom-location.conf
@@ -1,0 +1,7 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+dotnet_auto_instrumentation_agent_path_prefix = /path/from/config-file-custom-location/dotnet
+jvm_auto_instrumentation_agent_path = /path/from/config-file-custom-location/jvm/opentelemetry-javaagent.jar
+nodejs_auto_instrumentation_agent_path = /path/from/config-file-custom-location/node_js/node_modules/@opentelemetry-js/otel/instrument
+all_auto_instrumentation_agents_env_path = /etc/opentelemetry/default_auto_instrumentation_env.conf

--- a/test/scripts/create-sdk-dummy-files.sh
+++ b/test/scripts/create-sdk-dummy-files.sh
@@ -37,8 +37,10 @@ fi
 mkdir -p /__otel_auto_instrumentation/node_js/node_modules/@opentelemetry-js/otel/instrument
 touch /__otel_auto_instrumentation/node_js/node_modules/@opentelemetry-js/otel/instrument/index.js
 
-# Provide instrumentation files also in two more locations, for testing configuration via
-# /etc/opentelemetry/otelinject.conf and via environment variables NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH and friends.
+# Provide instrumentation files also in three more locations, for testing configuration via
+# /etc/opentelemetry/otelinject.conf/, OTEL_INJECTOR_CONFIG_FILE, and via environment variables
+# NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH and friends.
 mkdir -p /path/from
 cp -R /__otel_auto_instrumentation /path/from/config-file
 cp -R /__otel_auto_instrumentation /path/from/environment-variable
+cp -R /__otel_auto_instrumentation /path/from/config-file-custom-location

--- a/test/scripts/dotnet.tests
+++ b/test/scripts/dotnet.tests
@@ -7,15 +7,15 @@ run_test_case \
   "./dotnetapp verify-startup-hook-has-been-injected" \
   "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: true"
 
-# For test cases with the "configuration file" substring in their label, test/scripts/run-tests-within-container.sh
+# For test cases with the "default configuration file" substring in their label, test/scripts/run-tests-within-container.sh
 # will provide a configuration file in the expected location (/etc/opentelemetry/otelinject.conf).
 run_test_case \
-  "uses the .NET profiler path from the configuration file" \
+  "uses the .NET profiler path from the default configuration file" \
   "app" \
   "./dotnetapp verify-startup-hook-has-been-injected" \
   "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: true"
 run_test_case \
-  "the DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX environment variable overrides .NET profiler path from the configuration file" \
+  "the DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX environment variable overrides .NET profiler path from the default configuration file" \
   "app" \
   "./dotnetapp verify-startup-hook-has-been-injected" \
   "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: true" \

--- a/test/scripts/jvm.tests
+++ b/test/scripts/jvm.tests
@@ -13,15 +13,15 @@ run_test_case \
   "otel.injector.jvm.no_op_agent.has_been_loaded: true; some-property: some-value" \
   "JAVA_TOOL_OPTIONS=-Dsome-property=some-value"
 
-# For test cases with the "configuration file" substring in their label, test/scripts/run-tests-within-container.sh
+# For test cases with the "default configuration file" substring in their label, test/scripts/run-tests-within-container.sh
 # will provide a configuration file in the expected location (/etc/opentelemetry/otelinject.conf).
 run_test_case \
-  "uses the Java agent path from the configuration file" \
+  "uses the Java agent path from the default configuration file" \
   "app" \
   "java -jar Main.jar verify-javaagent-has-been-injected" \
   "otel.injector.jvm.no_op_agent.has_been_loaded: true"
 run_test_case \
-  "the JVM_AUTO_INSTRUMENTATION_AGENT_PATH environment variable overrides the Java agent path from the configuration file" \
+  "the JVM_AUTO_INSTRUMENTATION_AGENT_PATH environment variable overrides the Java agent path from the default configuration file" \
   "app" \
   "java -jar Main.jar verify-javaagent-has-been-injected" \
   "otel.injector.jvm.no_op_agent.has_been_loaded: true" \

--- a/test/scripts/node_js.tests
+++ b/test/scripts/node_js.tests
@@ -24,19 +24,32 @@ run_test_case \
   "NODE_OPTIONS: --require /__otel_auto_instrumentation/node_js/node_modules/@opentelemetry-js/otel/instrument --no-deprecation; NODE_OPTIONS: --require /__otel_auto_instrumentation/node_js/node_modules/@opentelemetry-js/otel/instrument --no-deprecation" \
   "NODE_OPTIONS=--no-deprecation"
 
-# For test cases with the "configuration file" substring in their label, test/scripts/run-tests-within-container.sh
-# will provide a configuration file in the expected location (/etc/opentelemetry/otelinject.conf).
+# For test cases with the "default configuration file" substring in their label, test/scripts/run-tests-within-container.sh
+# will provide a configuration file in the default location (/etc/opentelemetry/otelinject.conf).
 run_test_case \
-  "uses NODE_OPTIONS path from the configuration file" \
+  "uses NODE_OPTIONS path from the default configuration file" \
   "app" \
   "node index.js node-options" \
   "NODE_OPTIONS: --require /path/from/config-file/node_js/node_modules/@opentelemetry-js/otel/instrument"
 run_test_case \
-  "the NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH environment variable overrides the NODE_OPTIONS path from the configuration file" \
+  "the NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH environment variable overrides the NODE_OPTIONS path from the default configuration file" \
   "app" \
   "node index.js node-options" \
   "NODE_OPTIONS: --require /path/from/environment-variable/node_js/node_modules/@opentelemetry-js/otel/instrument" \
   "NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/environment-variable/node_js/node_modules/@opentelemetry-js/otel/instrument"
+
+run_test_case \
+  "uses NODE_OPTIONS path from the configuration file at a custom location" \
+  "app" \
+  "node index.js node-options" \
+  "NODE_OPTIONS: --require /path/from/config-file-custom-location/node_js/node_modules/@opentelemetry-js/otel/instrument" \
+  "OTEL_INJECTOR_CONFIG_FILE=/custom/config/path/otelinject.conf"
+run_test_case \
+  "the NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH environment variable overrides the NODE_OPTIONS path from the configuration file at a custom location" \
+  "app" \
+  "node index.js node-options" \
+  "NODE_OPTIONS: --require /path/from/environment-variable/node_js/node_modules/@opentelemetry-js/otel/instrument" \
+  "OTEL_INJECTOR_CONFIG_FILE=/custom/config/path/otelinject.conf NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/environment-variable/node_js/node_modules/@opentelemetry-js/otel/instrument"
 
 run_test_case \
   "setting NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH to the empty string disables the Node.js auto-instrumentation" \

--- a/test/scripts/run-tests-within-container.sh
+++ b/test/scripts/run-tests-within-container.sh
@@ -98,10 +98,10 @@ run_test_case() {
   fi
 
   set +e
-  match=$(expr "$test_case_label" : ".*configuration file.*")
+  match=$(expr "$test_case_label" : ".*default configuration file.*")
   set -e
   if [ "$match" -gt 0 ]; then
-    echo "providing configuration file at /etc/opentelemetry/otelinject.conf for test case \"$test_case_label\""
+    echo "providing configuration file at default location /etc/opentelemetry/otelinject.conf for test case \"$test_case_label\""
     cp otelinject.conf /etc/opentelemetry/otelinject.conf
   fi
 


### PR DESCRIPTION
This adds support for a new environment variable
OTEL_INJECTOR_CONFIG_FILE that determines from which path the injector's configuration file is read. If the variable is not set or empty, the configuration file is read from the default path
/etc/opentelemetry/otelinject.conf.

This is useful in environments where you want to provide a configuration file, but you do not want to make any assumptions about the underlying file system's structure. I.e. you want to keep all assets of the injector (injector binary, auto-instrumentation agents and the injector configuration) completely separate from standard OS directories like /etc.