### PR TITLE
ci: fix tag trigger in Github action workflow build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - ".*"
+      - "v[0-9]+.[0-9]+.[0-9]+**"
   pull_request:
 
 permissions:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       candidate:
         required: true
-        description: Release candidate version (like 0.70.0)
+        description: Release candidate version (like 0.70.0 or 0.70.0-20260109)
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
The expression is interpreted as a glob, not a regex; thus the previous expression ".*" would only match tags starting with a literal dot.

The new expression should match the tag format mentioned in RELEASING.md.