### PR TITLE
ci: fix attaching binaries/packages to the release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,4 +139,4 @@ jobs:
         with:
           body_path: release-notes.md
           files: |
-            artifacts/*
+            opentelemetry-injector/artifacts/*


### PR DESCRIPTION
The action actions/download-artifact adds an extra directory when downloading artifacts. The config for softprops/action-gh-release needs to account for that.