### PR TITLE
 ci: create tag for release automatically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  verify:
+  verify-and-build-binary:
     runs-on: ${{ matrix.ARCH == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
       matrix:
@@ -44,7 +44,7 @@ jobs:
           if-no-files-found: error
 
   build-package:
-    needs: verify
+    needs: verify-and-build-binary
     runs-on: ${{ matrix.ARCH == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
       matrix:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,7 +3,7 @@
 # or if performing maintenance on the Changelog, add either "chore" to the title
 # of the pull request or add the \"Skip Changelog\" label to disable this action.
 
-name: changelog
+name: Changelog
 
 on:
   pull_request:

--- a/.github/workflows/create-tag-for-release.yml
+++ b/.github/workflows/create-tag-for-release.yml
@@ -1,0 +1,21 @@
+name: Automation - Create Tag for Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag-for-release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Create tag for release
+        run: .github/workflows/scripts/create-tag-for-release.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     # Determine the version number that will be assigned to the release.
     inputs:
-      candidate:
+      version:
         required: true
-        description: Release candidate version (like 0.70.0 or 0.70.0-20260109)
+        description: Release version or release candidate version (like v0.70.0 or v0.70.0-20260109)
 permissions:
   contents: read
 jobs:
@@ -30,5 +30,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           REPO: open-telemetry/opentelemetry-injector
-          CANDIDATE: ${{ inputs.candidate }}
+          VERSION: ${{ inputs.version }}
         run: ./.github/workflows/scripts/prepare-release.sh

--- a/.github/workflows/scripts/create-tag-for-release.sh
+++ b/.github/workflows/scripts/create-tag-for-release.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+# Get the most recent commit message
+COMMIT_MSG=$(git log -1 --pretty=%B)
+
+# Check if commit message matches release pattern and extract version
+if [[ "$COMMIT_MSG" =~ ^docs:\ update\ changelog\ to\ prepare\ release\ (v[0-9]+\.[0-9]+\.[0-9]+.*)$ ]]; then
+  VERSION="${BASH_REMATCH[1]}"
+  echo "Found release commit for version: $VERSION."
+
+  # Create and push tag
+  echo "Creating tag for version $VERSION."
+  git config user.name opentelemetrybot
+  git config user.email 107717825+opentelemetrybot@users.noreply.github.com
+  git tag "$VERSION"
+  git push origin "$VERSION"
+  echo "Successfully created and pushed tag: $VERSION."
+else
+  echo "The most recent commit does not seem to be a release commit."
+  exit 0
+fi

--- a/.github/workflows/scripts/prepare-release.sh
+++ b/.github/workflows/scripts/prepare-release.sh
@@ -3,27 +3,37 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-PATTERN="^[0-9]+\.[0-9]+\.[0-9]+.*"
+# Usage: VERSION=v1.2.3 ./prepare-release.sh
+# Calls make chlog-update to compile all changelog entries from .chloggen and add them to the main CHANGELOG.md file,
+# then creates a PR with this change.
 
-if ! [[ ${CANDIDATE} =~ $PATTERN ]]
+PATTERN="^v[0-9]+\.[0-9]+\.[0-9]+.*"
+
+if [[ "$VERSION" == [0-9]* ]]; then
+  # normalize the VERSION input without leading "v"
+  VERSION="v$VERSION"
+fi
+
+if ! [[ ${VERSION} =~ $PATTERN ]]
 then
-    echo "CANDIDATE should follow a semver format and not be led by a v"
-    exit 1
+  echo "VERSION should follow the semver format (with a leading v), i.e. v1.2.3 or v1.2.3-qualifier."
+  exit 1
 fi
 
 git config user.name opentelemetrybot
 git config user.email 107717825+opentelemetrybot@users.noreply.github.com
 
-BRANCH="prepare-release-prs/${CANDIDATE}"
+BRANCH="prepare-release-prs/${VERSION}"
 git checkout -b "${BRANCH}"
 
-make chlog-update VERSION="v${CANDIDATE}"
+make chlog-update VERSION="${VERSION}"
 git add --all
-git commit -m "changelog update ${CANDIDATE}"
+git commit -m "docs: update changelog to prepare release ${VERSION}"
 
 git push --set-upstream origin "${BRANCH}"
 
-gh pr create --head "$(git branch --show-current)" --title "chore: prepare release ${CANDIDATE}" --body "
+gh pr create --head "$(git branch --show-current)" --title "chore: prepare release ${VERSION}" --body "
 The following commands were run to prepare this release:
-- make chlog-update VERSION=v${CANDIDATE}
+- make chlog-update VERSION=v${VERSION}
 "
+

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,45 +1,19 @@
 # Releasing the injector
 
-## Prepare the release
-
 An approver or maintainer can run the GitHub action to [prepare the release from the GitHub Actions page of the repository](https://github.com/open-telemetry/opentelemetry-injector/actions/workflows/prepare-release.yml).
 
-Enter a valid version string in the dialog (here _without_ the `v` prefix).
-The pattern for the version should be X.Y.Z for a regular release, or X.Y.Z-<additional-qualfier> for a release candidate.
+The pattern for the version should be vX.Y.Z for a regular release, or vX.Y.Z-<additional-qualfier> for a release candidate.
 
 The action will trigger the creation of a pull request for review by project approvers ([example](https://github.com/open-telemetry/opentelemetry-injector/pull/112)).
 
 Approvers approve the changelog and merge the PR.
 
-## Cut the release
+Merging the PR will trigger the workflow `.github/workflows/create-tag-for-release.yml` which will create a tag with the
+version number.
 
-_TODO_: this can be automated. See https://github.com/open-telemetry/opentelemetry-injector/issues/115
-
-To cut the release, approvers create a tag matching the commit of the PR that was just merged, with an additional `v` prefix.
-
-They can do so either through GitHub or by pushing it via `git tag vX.Y.Z && git push origin --tags`.
-
-They create a release on this tag and copy the section of the CHANGELOG.md for the release, adding more information as needed ([example](https://github.com/open-telemetry/opentelemetry-injector/releases/tag/v0.0.1-20251030)).
-
-If the release is not meant for production use, check the box to mark the release as pre-release.
-
-Publish the release with the "Publish release" button.
-
-## Add convenience binaries
-
-_TODO_: this can be automated. See https://github.com/open-telemetry/opentelemetry-injector/issues/115
-
-On your machine, run the following:
-* Switch to the tag for the release created in the previous step, i.e. `git fetch origin --tags; git checkout vX.Y.Z`.
-* Build assets:
-    ```bash
-    # clean local artifacts, build the injector binaries and packages for both architectures
-    $> make clean && make dist deb-package rpm-package ARCH=arm64 && make dist deb-package rpm-package ARCH=amd64
-    ```
-
-Upload the resulting files to the GitHub release assets:
-* the `libotelinject_*.so` binaries from `dist` for all supported CPU architectures
-* the Debian (`opentelemetry-injector-*.deb`) and RPM (`opentelemetry-injector-*.rpm`) packages for all supported CPU architectures from `instrumentation/dist/`
+Creating the tag will trigger the `build` GitHub action workflow, which will then create the GitHub release in the last
+job (`publish-stable`).
+(This can take a couple of minutes.)
 
 ## Announce the release
 


### PR DESCRIPTION
Also:
- update release instructions
- unify version number formats, i.e. allow a v prefix both when preparing the release and when actually cutting the release

Fixes #115.