### PR TITLE
chore: init pid for log messages only once

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -19,7 +19,9 @@ const empty_z_string = "\x00";
 
 const init_section_name = switch (builtin.target.os.tag) {
     .linux => ".init_array",
-    .macos => "__DATA,__mod_init_func", // needed to run tests locally on macOS
+    // Note: the injector does not support any OS besides Linux, this case is only here to support running Zig unit
+    // tests directly on Darwin.
+    .macos => "__DATA,__mod_init_func",
     else => {
         error.OsNotSupported;
     },


### PR DESCRIPTION
Commit 8f1535a9e19d922e3c920699098a4e44098a2bf1 introduced a change that crashes the Zig unit tests when executed directly on MacOS - in particular the std.os.linux.getpid() crashes when the OS is not Linux.

While support for any OS besides Linux is currently not a goal of this project, enabling developers to run the Zig unit tests directly on their native OS has value.

This commit also changes the initialization in src/print.zig to acquire the pid once, and then reuse that value when printing log messages.