### PR TITLE
test(integration): integrate binary validation test correctly

### DIFF
--- a/injector-integration-tests/binary/run-tests.sh
+++ b/injector-integration-tests/binary/run-tests.sh
@@ -10,27 +10,6 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-if [ -z "${EXPECTED_CPU_ARCHITECTURE:-}" ]; then
-  echo "EXPECTED_CPU_ARCHITECTURE is not set for $0."
-  exit 1
-fi
-
-arch=$(uname -m)
-arch_exit_code=$?
-if [ $arch_exit_code != 0 ]; then
-  printf "${RED}verifying CPU architecture failed:${NC}\n"
-  echo "exit code: $arch_exit_code"
-  echo "output: $arch"
-  exit 1
-elif [ "$arch" != "$EXPECTED_CPU_ARCHITECTURE" ]; then
-  printf "${RED}verifying CPU architecture failed:${NC}\n"
-  echo "expected: $EXPECTED_CPU_ARCHITECTURE"
-  echo "actual:   $arch"
-  exit 1
-else
-  printf "verifying CPU architecture %s successful\n" "$EXPECTED_CPU_ARCHITECTURE"
-fi
-
 injector_binary=/injector/libotelinject.so
 if [ ! -f $injector_binary ]; then
   printf "${RED}error: %s does not exist, not running any tests.${NC}\n" "$injector_binary"

--- a/injector-integration-tests/scripts/run-tests-for-container.sh
+++ b/injector-integration-tests/scripts/run-tests-for-container.sh
@@ -78,6 +78,13 @@ case "$runtime" in
     ;;
 esac
 
+if [[ "$TEST_SET" = "binary-validation.tests" ]]; then
+  runtime="-"
+  dockerfile_name="injector-integration-tests/binary/Dockerfile"
+  image_name=otel-injector-test-$ARCH-$LIBC-binary-validation
+  base_image_run=debian:bookworm-slim
+fi
+
 create_sdk_dummy_files_script="scripts/create-sdk-dummy-files.sh"
 if [[ "$TEST_SET" = "sdk-does-not-exist.tests" ]]; then
   create_sdk_dummy_files_script="scripts/create-no-sdk-dummy-files.sh"

--- a/injector-integration-tests/scripts/test-all.sh
+++ b/injector-integration-tests/scripts/test-all.sh
@@ -160,27 +160,6 @@ for arch in "${all_architectures[@]}"; do
       continue
     fi
   fi
-
-  # Run binary validation tests once per architecture.
-  # These tests validate ELF binary properties using readelf.
-  echo
-  echo ----------------------------------------
-  echo "running binary validation tests on $arch"
-  echo ----------------------------------------
-  set +e
-  ARCH="$arch" injector-integration-tests/scripts/run-binary-tests.sh
-  binary_validation_exit_code=$?
-  set -e
-  if [ $binary_validation_exit_code != 0 ]; then
-    printf "${RED}binary validation tests for %s failed (see above for details)${NC}\n" "$arch"
-    global_exit_code=1
-    summary="$summary\n$arch/binary-validation:\t${RED}failed${NC}"
-  else
-    printf "${GREEN}binary validation tests for %s were successful${NC}\n" "$arch"
-    summary="$summary\n$arch/binary-validation:\t${GREEN}ok${NC}"
-  fi
-  echo ----------------------------------------
-
   for libc_flavor in "${all_libc_flavors[@]}"; do
     if [[ -n "${libc_flavors[0]}" ]]; then
       if [[ $(echo "${libc_flavors[@]}" | grep -o "$libc_flavor" | wc -w) -eq 0 ]]; then


### PR DESCRIPTION
Commit 987888478e5d64745a37408feb4178c3d2969ed5 added the new binary validation test in a way so that it would run multiple times.

test-all.sh#run_tests_for_architecture_and_libc_flavor iterates over all test set files in injector-integration-tests/tests anyway, so there is no need to call this specific test set explicitly in test-all.sh.