### PR TITLE
chore: let renovate ignore injector-integration-tests/**/Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,9 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "schedule:weekly"
   ],
+  "ignorePaths": [
+    "injector-integration-tests/**/Dockerfile*"
+  ],
   "packageRules": [
     {
       "groupName": "all",
@@ -19,7 +22,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/(^|\\/).*\\.txt$/",
+        "/(^|\\/).*\\.txt$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (?:packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s+[A-Za-z0-9_]+?_VERSION\\s*:*\\??=\\s*[\"']?(?<currentValue>.+?)[\"']?\\s"


### PR DESCRIPTION
The actual base image versions are defined in the test scripts anyway, to switch between glibc and arm variants. Updating the image version in the Dockerfile (which is basically unused) would only lead to a false sense of updated-ness.

Plus, we might want start testing multiple image versions at some point, to ensure compatibility with older and newer framework (JVM, .NET, Node.js, ...) versions at some point.