### PR TITLE
[chore] remove stray v from PR body

### DIFF
--- a/.github/workflows/scripts/prepare-release.sh
+++ b/.github/workflows/scripts/prepare-release.sh
@@ -34,6 +34,6 @@ git push --set-upstream origin "${BRANCH}"
 
 gh pr create --head "$(git branch --show-current)" --title "chore: prepare release ${VERSION}" --body "
 The following commands were run to prepare this release:
-- make chlog-update VERSION=v${VERSION}
+- make chlog-update VERSION=${VERSION}
 "
 


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-injector/pull/234 - a stray `v` is placed before the version number.