### PR TITLE
[chore] fix release regular expression

### DIFF
--- a/.github/workflows/scripts/create-tag-for-release.sh
+++ b/.github/workflows/scripts/create-tag-for-release.sh
@@ -11,7 +11,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 COMMIT_MSG=$(git log -1 --pretty=%B)
 
 # Check if commit message matches release pattern and extract version
-if [[ "$COMMIT_MSG" =~ ^docs:\ update\ changelog\ to\ prepare\ release\ (v[0-9]+\.[0-9]+\.[0-9]+(-?\w+)?)\ .*$ ]]; then
+if [[ "$COMMIT_MSG" =~ ^docs:\ update\ changelog\ to\ prepare\ release\ (v[0-9]+\.[0-9]+\.[0-9]+(-[[:alnum:]]+)?).*$ ]]; then
   VERSION="${BASH_REMATCH[1]}"
   echo "Found release commit for version: $VERSION."
 


### PR DESCRIPTION
Two problems:
* `?:` bash doesn't support non-capturing groups. Drop it.
* `.*` replaced by `\w+`: bash is applying greediness to the first `.*` it meets - reducing to word characters helps. There is no way to apply ungreediness to RE regexps.