### PR TITLE
feat: add initial Python support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ agents:
 - [Java](https://opentelemetry.io/docs/zero-code/java/)
 - [Node.js](https://opentelemetry.io/docs/zero-code/js/)
 - [.NET](https://opentelemetry.io/docs/zero-code/dotnet/)
+- [Python](https://opentelemetry.io/docs/zero-code/python/)
 
 ## Activation and Configuration
 
@@ -50,6 +51,7 @@ This method requires `root` privileges.
    dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet
    jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/jvm/javaagent.jar
    nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+   python_auto_instrumentation_agent_path=/usr/lib/opentelemetry/python/opentelemetry/instrumentation/auto_instrumentation
    ```
 
    You can override the location of the configuration file by setting `OTEL_INJECTOR_CONFIG_FILE`.
@@ -59,12 +61,13 @@ This method requires `root` privileges.
 
    - You want to selectively disable auto-instrumentation for a specific runtime, by setting the respective path
      to an empty string in the configuration file.
-     For example, the following file would leave JVM and Node.js auto-instrumentation active, while disabling .NET
+     For example, the following file would leave JVM, Node.js and Python auto-instrumentation active, while disabling .NET
      auto-instrumentation:
       ```
       dotnet_auto_instrumentation_agent_path_prefix=
       jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/jvm/javaagent.jar
       nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+      python_auto_instrumentation_agent_path=/usr/lib/opentelemetry/python/opentelemetry/instrumentation/auto_instrumentation
       ```
    - You want to selectively enable (or disable) auto-instrumentation for a subset of programs (services) on your system.
      For example, you may want to only enable instrumentation of services that match a specific executable path pattern, or
@@ -77,6 +80,7 @@ This method requires `root` privileges.
      agent files
    - `JVM_AUTO_INSTRUMENTATION_AGENT_PATH`: the path to the Java auto-instrumentation agent JAR file
    - `NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH`: the path to the Node.js auto-instrumentation agent registration file
+   - `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH`: the path to the Python auto-instrumentation agent module
    - `OTEL_INJECTOR_INCLUDE_PATHS`: a comma-separated list of glob patterns to match executable paths
    - `OTEL_INJECTOR_EXCLUDE_PATHS`: a comma-separated list of glob patterns to exclude executable paths
    - `OTEL_INJECTOR_INCLUDE_WITH_ARGUMENTS`: a comma-separated list of glob patterns to match process arguments
@@ -87,6 +91,7 @@ This method requires `root` privileges.
     - `DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=""` to disable .NET auto-instrumentation
     - `JVM_AUTO_INSTRUMENTATION_AGENT_PATH=""` to disable JVM auto-instrumentation
     - `NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=""` to disable Node.js auto-instrumentation
+    - `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH=""` to disable Python auto-instrumentation
 
 3. (Optional) The default env agent configuration file `/etc/opentelemetry/default_auto_instrumentation_env.conf` is empty (use
    `all_auto_instrumentation_agents_env_path` option to specify other path). Environment variables added to this file
@@ -107,6 +112,8 @@ This method requires `root` privileges.
 When providing your own instrumentation files (for example via environment variables like `DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX`) the following directory structure is expected:
 - `JVM_AUTO_INSTRUMENTATION_AGENT_PATH`: This path must point to the Java auto-instrumentation agent JAR file `opentelemetry-javaagent.jar`.
 - `NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH`: The path to an installation of the npm module `@opentelemetry/auto-instrumentations-node`.
+- `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH`: The path to an installation of the python package `opentelemetry-distro`.
+`@opentelemetry/auto-instrumentations-python`.
 - `DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX`: this path must be a directory that contains the following
   subdirectories and files:
    - For `x86_64` systems using `glibc`:
@@ -137,12 +144,14 @@ Check the following for details about the auto-instrumtation agents and further 
 - [Java](https://opentelemetry.io/docs/zero-code/java/agent/configuration/)
 - [Node.js](https://opentelemetry.io/docs/zero-code/js/configuration/)
 - [.NET](https://opentelemetry.io/docs/zero-code/dotnet/configuration/)
+- [Python](https://opentelemetry.io/docs/zero-code/python/configuration/)
 
 ### Environment Modifications
 
 Here is an overview of the modifications that the injector will apply:
 
 * It sets (or appends to) `NODE_OPTIONS` to activate the Node.js instrumentation agent.
+* It sets (or appends to) `PYTHONPATH` to activate the Python instrumentation agent.
 * It adds a `-javaagent` flag to `JAVA_TOOL_OPTIONS` to activate the Java OTel SDK.
 * It sets the required environment variables for activating the OpenTelemetry SDK for .NET:
     * `CORECLR_ENABLE_PROFILING`
@@ -242,6 +251,7 @@ included for instrumentation:
 dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet
 jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+python_auto_instrumentation_agent_path=/usr/lib/opentelemetry/python/opentelemetry/instrumentation/auto_instrumentation
 
 include_paths=/app/*,/utilities/*
 exclude_paths=/app/system/*
@@ -252,6 +262,7 @@ look at the following example:
 dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet
 jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+python_auto_instrumentation_agent_path=/usr/lib/opentelemetry/python/opentelemetry/instrumentation/auto_instrumentation
 
 include_paths=/app/*,/utilities/*,*.exe
 exclude_with_arguments=-javaagent:*,*@opentelemetry-js*,-Xmx?m

--- a/packaging/fpm/common.sh
+++ b/packaging/fpm/common.sh
@@ -33,6 +33,10 @@ DOTNET_OS_NAME="linux"
 DOTNET_AGENT_RELEASE_URL="https://github.com/open-telemetry/$DOTNET_ARTIFACE_BASE_NAME/releases/download"
 DOTNET_AGENT_INSTALL_DIR="${INSTALL_DIR}/dotnet"
 
+PYTHON_AGENT_RELEASE_PATH="${FPM_DIR}/../python-agent-release.txt"
+PYTHON_OTLP_RELEASE_PATH="${FPM_DIR}/../python-otlp-release.txt"
+PYTHON_AGENT_INSTALL_DIR="${INSTALL_DIR}/python"
+
 PREUNINSTALL_PATH="$FPM_DIR/preuninstall.sh"
 
 get_version() {
@@ -77,6 +81,14 @@ download_nodejs_agent() {
     rm opentelemetry-auto-instrumentations-node.tgz
     popd
     popd
+}
+
+download_python_agent() {
+    local agent_tag="$1"
+    local otlp_tag="$2"
+    local dest="$3"
+
+    pip install opentelemetry-distro==${agent_tag} opentelemetry-exporter-otlp==${otlp_tag} --target ${dest}
 }
 
 download_dotnet_agent() {
@@ -125,9 +137,12 @@ setup_files_and_permissions() {
     local java_agent_release
     local nodejs_agent_release
     local dotnet_agent_release
+    local python_agent_release
     java_agent_release="$(tail -n 1 <"$JAVA_AGENT_RELEASE_PATH")"
     nodejs_agent_release="$(tail -n 1 <"$NODEJS_AGENT_RELEASE_PATH")"
     dotnet_agent_release="$(tail -n 1 <"$DOTNET_AGENT_RELEASE_PATH")"
+    python_agent_release="$(tail -n 1 <"$PYTHON_AGENT_RELEASE_PATH")"
+    python_otlp_release="$(tail -n 1 <"$PYTHON_OTLP_RELEASE_PATH")"
 
     mkdir -p "${buildroot}$(dirname $libotelinject_INSTALL_PATH)"
     cp -f "$libotelinject" "${buildroot}$libotelinject_INSTALL_PATH"
@@ -141,6 +156,9 @@ setup_files_and_permissions() {
 
     download_dotnet_agent "$dotnet_agent_release" "${buildroot}${DOTNET_AGENT_INSTALL_DIR}"
     sudo chmod -R 755 "${buildroot}$DOTNET_AGENT_INSTALL_DIR"
+
+    download_python_agent "$python_agent_release" "$python_otlp_release" "${buildroot}${PYTHON_AGENT_INSTALL_DIR}"
+    sudo chmod -R 755 "${buildroot}$PYTHON_AGENT_INSTALL_DIR"
 
     mkdir -p  "${buildroot}$CONFIG_DIR_INSTALL_PATH"
     cp -rf "$CONFIG_DIR_REPO_PATH"/* "${buildroot}$CONFIG_DIR_INSTALL_PATH"/

--- a/packaging/fpm/etc/opentelemetry/otelinject.conf
+++ b/packaging/fpm/etc/opentelemetry/otelinject.conf
@@ -4,3 +4,4 @@ all_auto_instrumentation_agents_env_path=/etc/opentelemetry/default_auto_instrum
 dotnet_auto_instrumentation_agent_path_prefix=/usr/lib/opentelemetry/dotnet
 jvm_auto_instrumentation_agent_path=/usr/lib/opentelemetry/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/usr/lib/opentelemetry/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+python_auto_instrumentation_agent_path=/usr/lib/opentelemetry/python/opentelemetry/instrumentation/auto_instrumentation

--- a/packaging/python-agent-release.txt
+++ b/packaging/python-agent-release.txt
@@ -1,0 +1,2 @@
+# renovate: datasource=pip depName=opentelemetry-distro
+0.60b1

--- a/packaging/python-otlp-release.txt
+++ b/packaging/python-otlp-release.txt
@@ -1,0 +1,2 @@
+# renovate: datasource=pip depName=opentelemetry-exporter-otlp
+1.39.1

--- a/src/python.zig
+++ b/src/python.zig
@@ -1,0 +1,63 @@
+const std = @import("std");
+const config = @import("config.zig");
+const print = @import("print.zig");
+
+pub const pyton_path_env_var_name = "PYTHONPATH";
+
+pub fn getModule(allocator: std.mem.Allocator, module: []const u8, pypath: []const u8) ?[:0]u8 {
+    if (module.len == 0) {
+        print.printInfo("Skipping Python injection because no configuration was provided", .{});
+        return null;
+    }
+
+    if (std.mem.indexOf(u8, pypath, module) != null) {
+        print.printError("Skipping Python injection because an auto-instrumentation agent was already detected in \"PYTHONPATH\"", .{});
+        return null;
+    }
+
+    std.fs.cwd().access(module, .{}) catch |err| {
+        print.printError("Skipping Python injection because the agent module at {s} could not be accessed: {}", .{ module, err });
+        return null;
+    };
+
+    const new_pypath = std.mem.joinZ(allocator, ":", &[_][]const u8{ module, pypath }) catch {
+        return null;
+    };
+    return new_pypath;
+}
+
+test "getModule: skip when no config is provided" {
+    const module = getModule(std.testing.allocator, "", "");
+    try std.testing.expectEqual(null, module);
+}
+
+test "getModule: skip python agent path is already in PYTHONPATH" {
+    const old_pythonpath = "/usr/local:/foo/bar/foobar:/usr/local/lib/python-otel-agent";
+    const maybe_module = getModule(std.testing.allocator, "/usr/local/lib/python-otel-agent", old_pythonpath);
+    try std.testing.expectEqual(null, maybe_module);
+}
+
+test "getModule: module does not exist or not accessible" {
+    const maybe_module = getModule(std.testing.allocator, "/var/foo/bar", "");
+    try std.testing.expectEqual(null, maybe_module);
+}
+
+test "getModule: prepend module path" {
+    const testing = std.testing;
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+
+    const agent_module = try tmp_dir.dir.createFile("python-otel-agent", .{});
+    defer agent_module.close();
+
+    const agent_module_path = try tmp_dir.dir.realpathAlloc(testing.allocator, "python-otel-agent");
+    defer testing.allocator.free(agent_module_path);
+
+    const old_pythonpath = "/usr/local:/foo/bar";
+    const maybe_module = getModule(std.testing.allocator, agent_module_path, old_pythonpath);
+    try std.testing.expect(maybe_module != null);
+    defer testing.allocator.free(maybe_module.?);
+
+    try std.testing.expectStringStartsWith(maybe_module.?, agent_module_path);
+}

--- a/src/root.zig
+++ b/src/root.zig
@@ -9,6 +9,7 @@ const dotnet = @import("dotnet.zig");
 const libc = @import("libc.zig");
 const jvm = @import("jvm.zig");
 const nodejs = @import("nodejs.zig");
+const python = @import("python.zig");
 const print = @import("print.zig");
 const res_attrs = @import("resource_attributes.zig");
 const types = @import("types.zig");
@@ -155,6 +156,12 @@ fn initEnviron() callconv(.c) void {
         allocator,
         libc_info.setenv_fn_ptr,
         dotnet.otel_dotnet_auto_home_env_var_name,
+        configuration,
+    );
+    modifyEnvironmentVariable(
+        allocator,
+        libc_info.setenv_fn_ptr,
+        python.pyton_path_env_var_name,
         configuration,
     );
 
@@ -345,6 +352,8 @@ fn getEnvValue(
         if (dotnet.getDotnetValues(allocator, configuration)) |v| {
             return v.otel_auto_home;
         }
+    } else if (std.mem.eql(u8, name, python.pyton_path_env_var_name)) {
+        return python.getModule(allocator, configuration.python_auto_instrumentation_agent_path, original_value orelse "");
     }
 
     return null;

--- a/src/test.zig
+++ b/src/test.zig
@@ -11,6 +11,7 @@ pub const nodejs = @import("nodejs.zig");
 pub const patterns_matcher = @import("patterns_matcher.zig");
 pub const patterns_util = @import("patterns_util.zig");
 pub const print = @import("print.zig");
+pub const python = @import("python.zig");
 pub const res_attrs_test = @import("resource_attributes_test.zig");
 
 test {

--- a/unit-test-assets/config/all_values.conf
+++ b/unit-test-assets/config/all_values.conf
@@ -1,6 +1,7 @@
 dotnet_auto_instrumentation_agent_path_prefix=/custom/path/to/dotnet/instrumentation
 jvm_auto_instrumentation_agent_path=/custom/path/to/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/custom/path/to/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
+python_auto_instrumentation_agent_path=/custom/path/to/python
 all_auto_instrumentation_agents_env_path=/custom/path/to/auto_instrumentation_env.conf
 include_paths=/app/*,/home/user/test/*
 include_paths=/another_dir/*

--- a/unit-test-assets/config/with_comments_and_whitespace.conf
+++ b/unit-test-assets/config/with_comments_and_whitespace.conf
@@ -13,5 +13,7 @@ dotnet_auto_instrumentation_agent_path_prefix	=	  /custom/path/to/dotnet/instrum
 
 	nodejs_auto_instrumentation_agent_path = /custom/path/to/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js    # end-of-line comment
 
+python_auto_instrumentation_agent_path=/custom/path/to/python
+
 an invalid line that will be ignored
 


### PR DESCRIPTION
This PR introduces initial support for Python applications by adding the Python OpenTelemetry zero-code instrumentation agent and configuring it via `PYTHONPATH`.

The current approach requires users to manually install the necessary instrumentation packages. This is not ideal, and a future improvement could be to automatically download these dependencies (for example via a `sitecustomize.py`). However, that approach may introduce application startup latency, so it’s intentionally deferred for now.

Changes:
  - Documentation updates in README.md with Python setup instructions.
  - Packaging of the Python OpenTelemetry zero-code instrumentation agent and OTLP exporter.
  - Populate PYTHONPATH to enable instrumentation.

Resolves #8