### PR TITLE
chore: fix JVM integration test

### DIFF
--- a/injector-integration-tests/runtimes/jvm/Dockerfile
+++ b/injector-integration-tests/runtimes/jvm/Dockerfile
@@ -1,8 +1,25 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-ARG base_image_run="eclipse-temurin:25@sha256:42fc3fe6804ec612f5ef8a613f8c06d8dd578de6207336077387d4cb32edaa9b"
+ARG base_image_build="maven:3.9-eclipse-temurin-21"
+ARG base_image_run="eclipse-temurin:21-jre"
+
+FROM --platform=$BUILDPLATFORM ${base_image_build} AS build
+
+WORKDIR /usr/src/otel/injector/
+
+COPY injector-integration-tests/runtimes/jvm /usr/src/otel/injector/
+RUN mvn package -B -q
+
+# final stage/image
 FROM ${base_image_run}
+
+RUN mkdir -p /etc/opentelemetry && chmod 777 /etc/opentelemetry
+
+WORKDIR /usr/src/otel/injector/
+
+COPY --from=build /usr/src/otel/injector/no-op-agent/target/no-op-agent.jar no-op-agent/no-op-agent.jar
+COPY --from=build /usr/src/otel/injector/app/target/Main.jar app/Main.jar
 
 ARG injector_binary
 RUN if [ -z "$injector_binary" ]; then \
@@ -15,19 +32,6 @@ RUN if [ -z "$create_sdk_dummy_files_script" ]; then \
       echo "Error: build argument create_sdk_dummy_files_script is required but not set."; \
       exit 1; \
     fi
-
-RUN mkdir -p /etc/opentelemetry && chmod 777 /etc/opentelemetry
-
-WORKDIR /usr/src/otel/injector/
-
-COPY injector-integration-tests/runtimes/jvm/no-op-agent no-op-agent
-RUN cd no-op-agent/src/main/java && javac io/opentelemetry/javaagent/NoOpAgent.java && \
-    jar -c -m manifest.mf -f no-op-agent.jar io/opentelemetry/javaagent/NoOpAgent.class && \
-    cp no-op-agent.jar ../../../
-
-COPY injector-integration-tests/runtimes/jvm app
-RUN cd app && javac Main.java && \
-    jar cfe Main.jar Main Main.class
 
 COPY injector-integration-tests/scripts/run-tests-within-container.sh scripts/
 COPY injector-integration-tests/scripts/create-*.sh scripts/

--- a/injector-integration-tests/runtimes/jvm/app/pom.xml
+++ b/injector-integration-tests/runtimes/jvm/app/pom.xml
@@ -1,0 +1,34 @@
+<!-- Copyright The OpenTelemetry Authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.opentelemetry.injector.test</groupId>
+    <artifactId>jvm-integration-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>app</artifactId>
+  <packaging>jar</packaging>
+
+  <build>
+    <finalName>Main</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>test.Main</mainClass>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/injector-integration-tests/runtimes/jvm/app/src/main/java/test/Main.java
+++ b/injector-integration-tests/runtimes/jvm/app/src/main/java/test/Main.java
@@ -1,5 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
+package test;
 
 import java.util.Map;
 

--- a/injector-integration-tests/runtimes/jvm/no-op-agent/pom.xml
+++ b/injector-integration-tests/runtimes/jvm/no-op-agent/pom.xml
@@ -1,0 +1,34 @@
+<!-- Copyright The OpenTelemetry Authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.opentelemetry.injector.test</groupId>
+    <artifactId>jvm-integration-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>no-op-agent</artifactId>
+  <packaging>jar</packaging>
+
+  <build>
+    <finalName>no-op-agent</finalName>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.4.2</version>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Premain-Class>io.opentelemetry.javaagent.NoOpAgent</Premain-Class>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/injector-integration-tests/runtimes/jvm/no-op-agent/src/main/java/manifest.mf
+++ b/injector-integration-tests/runtimes/jvm/no-op-agent/src/main/java/manifest.mf
@@ -1,1 +1,0 @@
-Premain-Class: io.opentelemetry.javaagent.NoOpAgent

--- a/injector-integration-tests/runtimes/jvm/pom.xml
+++ b/injector-integration-tests/runtimes/jvm/pom.xml
@@ -1,0 +1,23 @@
+<!-- Copyright The OpenTelemetry Authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.opentelemetry.injector.test</groupId>
+  <artifactId>jvm-integration-tests</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <modules>
+    <module>no-op-agent</module>
+    <module>app</module>
+  </modules>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+</project>

--- a/injector-integration-tests/scripts/run-tests-for-container.sh
+++ b/injector-integration-tests/scripts/run-tests-for-container.sh
@@ -66,10 +66,11 @@ case "$runtime" in
     ;;
   "jvm")
     dockerfile_name="injector-integration-tests/runtimes/jvm/Dockerfile"
-    base_image_run=eclipse-temurin:11
+    base_image_build=maven:3.9-eclipse-temurin-21
+    base_image_run=eclipse-temurin:21-jre
     if [[ "$LIBC" = "musl" ]]; then
-      # Older images of eclipse-temurin:xx-alpine (before 21) are single platform and do not support arm64.
-      base_image_run=eclipse-temurin:21-alpine
+      base_image_build=maven:3.9-eclipse-temurin-21-alpine
+      base_image_run=eclipse-temurin:21-jre-alpine
     fi
     ;;
   "nodejs")


### PR DESCRIPTION
`make tests` fails on Mac OS X due to some QEMU compatibility issue:

```
docker run --rm --platform linux/amd64 --env EXPECTED_CPU_ARCHITECTURE=x86_64 --env LIBC_FLAVOR=glibc --env TEST_SET=jvm.tests --env TEST_CASES= --env TEST_CASES_CONTAINING= --env VERBOSE= otel-injector-test-amd64-glibc-jvm
  exec /__cacert_entrypoint.sh: exec format error
```

This commit updates the base image to a more recent Eclipse Temurin.

It also reduces the brittleness of the test by using Maven to build the setup, as opposed to low-level primitives like javac, at the cost or a longer build time (because Maven likes to backup the Internet every time it builds something).