### PR TITLE
chore: revert "docs: update changelog to prepare release v0.1.1-20260211"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 <!-- next version -->
 
-## v0.1.1-20260211
-
-<!-- previous-version -->
-
 ## v0.1.0
 
 ### 💡 Enhancements 💡


### PR DESCRIPTION
This reverts commit c483c6343b667975037a4a39fbaa98e3b883e9b4.

This was a test release meant to test the release automation.