### PR TITLE
ci: temporarily allow a release build for any tag pattern

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+**"
+      - "*"
   pull_request:
 
 permissions:


### PR DESCRIPTION
This is an attempt to rule out that the pattern is the issue in #252.