### PR TITLE
chore: revert "docs: update changelog to prepare release v0.1.1-20260216 (#261)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 <!-- next version -->
 
-## v0.1.1-2026021602
-
-<!-- previous-version -->
-
 ## v0.1.0
 
 ### 💡 Enhancements 💡


### PR DESCRIPTION
This reverts commit 58d9e5a4b4122794752971a7990f0b4b92688902.

This was a test release meant to test the release automation.