### PR TITLE
feat(config): add support for auto_instrumentation_disabled list

### DIFF
--- a/.chloggen/add_option_to_disable_auto_instrumentation.yaml
+++ b/.chloggen/add_option_to_disable_auto_instrumentation.yaml
@@ -1,0 +1,11 @@
+change_type: enhancement
+component: injection
+note: Add option to disable auto-instrumentation for specific runtimes or all runtimes
+issues: [240]
+subtext: When the config file option `auto_instrumentation_disabled` or the environment variable
+  `OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED` is set to `*`, auto-instrumentation for all runtimes will be disabled.
+  When set to a comma-separated list of runtimes, auto-instrumentation for the listed runtimes will be disabled.
+  In contrast to `OTEL_INJECTOR_DISABLED=true` which disables the injector wholesale, injection of additional resource
+  attributes via `OTEL_RESOURCE_ATTRIBUTES` still happens when `auto_instrumentation_disabled` or
+  `OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED` are used.
+change_logs: [user]

--- a/injector-integration-tests/tests/dotnet.tests
+++ b/injector-integration-tests/tests/dotnet.tests
@@ -35,6 +35,18 @@ run_test_case \
   "OTEL_INJECTOR_CONFIG_FILE=/custom/config/path/otelinject.conf DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/environment-variable/dotnet"
 
 run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=dotnet disables setting CORECLR_PROFILER_PATH" \
+  "app" \
+  "./dotnetapp coreclr-profiler-path" \
+  "CORECLR_PROFILER_PATH: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=dotnet"
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=* disables setting CORECLR_PROFILER_PATH" \
+  "app" \
+  "./dotnetapp coreclr-profiler-path" \
+  "CORECLR_PROFILER_PATH: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=*"
+run_test_case \
   "setting DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX to the empty string disables setting CORECLR_PROFILER_PATH" \
   "app" \
   "./dotnetapp coreclr-profiler-path" \
@@ -67,6 +79,18 @@ run_test_case \
   "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: true" \
   "DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/environment-variable/dotnet"
 
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=dotnet will result in the .NET auto-instrumentation not being loaded" \
+  "app" \
+  "./dotnetapp verify-startup-hook-has-been-injected" \
+  "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=dotnet"
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=* will result in the .NET auto-instrumentation not being loaded" \
+  "app" \
+  "./dotnetapp verify-startup-hook-has-been-injected" \
+  "otel_injector_dotnet_no_op_startup_hook_has_been_loaded: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=*"
 run_test_case \
   "setting DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX to the empty string will result in the .NET auto-instrumentation not being loaded" \
   "app" \

--- a/injector-integration-tests/tests/jvm.tests
+++ b/injector-integration-tests/tests/jvm.tests
@@ -28,6 +28,18 @@ run_test_case \
   "JVM_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/environment-variable/jvm/javaagent.jar"
 
 run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=jvm disables the JVM auto-instrumentation" \
+  "app" \
+  "java -jar Main.jar verify-javaagent-has-been-injected" \
+  "otel.injector.jvm.no_op_agent.has_been_loaded: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=jvm"
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=* disables the JVM auto-instrumentation" \
+  "app" \
+  "java -jar Main.jar verify-javaagent-has-been-injected" \
+  "otel.injector.jvm.no_op_agent.has_been_loaded: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=*"
+run_test_case \
   "setting JVM_AUTO_INSTRUMENTATION_AGENT_PATH to the empty string disables the JVM auto-instrumentation" \
   "app" \
   "java -jar Main.jar verify-javaagent-has-been-injected" \

--- a/injector-integration-tests/tests/nodejs.tests
+++ b/injector-integration-tests/tests/nodejs.tests
@@ -58,6 +58,18 @@ run_test_case \
   "OTEL_INJECTOR_CONFIG_FILE=/custom/config/path/otelinject.conf NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/environment-variable/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js"
 
 run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=nodejs disables the Node.js auto-instrumentation" \
+  "app" \
+  "node index.js node-options" \
+  "NODE_OPTIONS: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=nodejs"
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=* disables the Node.js auto-instrumentation" \
+  "app" \
+  "node index.js node-options" \
+  "NODE_OPTIONS: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=*"
+run_test_case \
   "setting NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH to the empty string disables the Node.js auto-instrumentation" \
   "app" \
   "node index.js node-options" \

--- a/injector-integration-tests/tests/python.tests
+++ b/injector-integration-tests/tests/python.tests
@@ -47,6 +47,18 @@ run_test_case \
   "OTEL_INJECTOR_CONFIG_FILE=/custom/config/path/otelinject.conf PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/environment-variable/python"
 
 run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=python disables the Python auto-instrumentation" \
+  "app" \
+  "python app.py pythonpath" \
+  "PYTHONPATH: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=python"
+run_test_case \
+  "setting OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=* disables the Python auto-instrumentation" \
+  "app" \
+  "python app.py pythonpath" \
+  "PYTHONPATH: -" \
+  "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=*"
+run_test_case \
   "setting PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX to the empty string disables the Python auto-instrumentation" \
   "app" \
   "python app.py pythonpath" \
@@ -72,7 +84,7 @@ run_test_case \
   "CUSTOM_ENV_VAR: -"
 
 run_test_case \
-  "setting OTEL_INJECTOR_DISABLED to true empty string disables the Python auto-instrumentation" \
+  "setting OTEL_INJECTOR_DISABLED to true string disables the Python auto-instrumentation" \
   "app" \
   "python app.py pythonpath" \
   "PYTHONPATH: -" \

--- a/unit-test-assets/config/all_values.conf
+++ b/unit-test-assets/config/all_values.conf
@@ -3,6 +3,7 @@ jvm_auto_instrumentation_agent_path=/custom/path/to/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/custom/path/to/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
 python_auto_instrumentation_agent_path_prefix=/custom/path/to/python
 all_auto_instrumentation_agents_env_path=/custom/path/to/auto_instrumentation_env.conf
+auto_instrumentation_disabled=nodejs
 include_paths=/app/*,/home/user/test/*
 include_paths=/another_dir/*
 exclude_paths=/usr/*,/opt/*

--- a/unit-test-assets/config/auto_instrumentation_disabled_list.conf
+++ b/unit-test-assets/config/auto_instrumentation_disabled_list.conf
@@ -1,0 +1,1 @@
+auto_instrumentation_disabled=dotnet,jvm,nodejs,python

--- a/unit-test-assets/config/auto_instrumentation_disabled_multiple_times.conf
+++ b/unit-test-assets/config/auto_instrumentation_disabled_multiple_times.conf
@@ -1,0 +1,2 @@
+auto_instrumentation_disabled=dotnet
+auto_instrumentation_disabled=jvm

--- a/unit-test-assets/config/auto_instrumentation_disabled_star.conf
+++ b/unit-test-assets/config/auto_instrumentation_disabled_star.conf
@@ -1,0 +1,1 @@
+auto_instrumentation_disabled=*

--- a/unit-test-assets/config/with_comments_and_whitespace.conf
+++ b/unit-test-assets/config/with_comments_and_whitespace.conf
@@ -7,6 +7,8 @@
  all_auto_instrumentation_agents_env_path=/custom/path/to/auto_instrumentation_env.conf
 
 
+auto_instrumentation_disabled      =jvm
+
 dotnet_auto_instrumentation_agent_path_prefix	=	  /custom/path/to/dotnet/instrumentation   # end-of-line comment
 
    jvm_auto_instrumentation_agent_path  =  /custom/path/to/jvm/javaagent.jar    # end-of-line comment


### PR DESCRIPTION
This adds a new supported key to the configuration file, named auto_instrumentation_disabled

The value can be either the literal "*" character to disable auto-instrumentation for all supported runtimes, or it can be a comma-separated list of runtimes, to selectively disable auto-instrumentation for these runtimes only.

In both cases, adding resource attributes via the injector is still enabled.

Also adds support for an environment variable with the same semantics, OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED.

fixes #240