### PR TITLE
ci: only allow release builds for release tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     tags:
-      - "*"
+      - "v[0-9]+.[0-9]+.[0-9]+**"
   pull_request:
 
 permissions:


### PR DESCRIPTION
This reverts commit c31430f11d4de901b5ab521e9e6bb9469d56b7f8.