### PR TITLE
Include / exclude matches all, with conditions ANDed and entries ORd

### DIFF
--- a/.chloggen/rework-include-exclude-logic.yaml
+++ b/.chloggen/rework-include-exclude-logic.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: injector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where `include_paths` was ignored when `include_with_arguments` was not configured. Each non-empty include/exclude setting now adds an independent condition (AND across settings, OR within entries).
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [312]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/README.md
+++ b/README.md
@@ -232,16 +232,19 @@ The injector's log message will be written to `stderr` of the process that is be
 
 If you want to selectively enable (or disable) auto-instrumentation for a subset of programs (services) on your system,
 the configuration file provides a couple of settings which can be used alone or in combination to produce
-the desired outcome:
+the desired outcome.
+
+By default, all processes are instrumented. Each non-empty include setting adds a condition that a process
+must satisfy to be instrumented — all such conditions must be met (AND across settings). Within a single
+setting, entries are ORed: any one matching pattern is sufficient to satisfy that setting. Exclusions take
+precedence over inclusions.
+
   - `include_paths` - A comma-separated list of glob patterns to match executable paths.
-    If you do not specify anything here, the injector defaults to instrumenting **all executables**.
   - `exclude_paths` - A comma-separated list of glob patterns to exclude executable paths.
   - `include_with_arguments` - A comma-separated list of glob patterns to match process arguments.
-    If you do not specify anything here, the injector defaults to instrumenting **all executables**.
   - `exclude_with_arguments` - A comma-separated list of glob patterns to exclude process arguments.
 
-If an executable matches both an inclusion and an exclusion criterion, the exclusion takes
-precedence. For example, in the following configuration, all program executables in the
+For example, in the following configuration, all program executables in the
 `/app/system/` directory will not be instrumented, even though the `/app` directory is
 included for instrumentation:
 ```
@@ -263,27 +266,25 @@ include_paths=/app/*,/utilities/*,*.exe
 exclude_with_arguments=-javaagent:*,*@opentelemetry-js*,-Xmx?m
 include_with_arguments=*MyProject*.jar,*app.js
 ```
-In the example above we'll instrument:
-  - any programs that run from the `/app` and `/utilities` directories
-  - any programs that have an `.exe` extension
-  - any programs that have a command line argument containing `MyProject`
-  in the name and ending with the extension `.jar`
-  - any programs that have a program argument ending in `app.js`
-  - however, for all included programs, the injector **will avoid**:
-    - all programs that have a command line argument starting with
-    `-javaagent:`
-    - all programs that have a command line argument that contains `@opentelemetry-js`
-    - all `java` programs that run with a single digit megabytes of maximum memory
+In the example above, both `include_paths` and `include_with_arguments` are configured, so a process
+must satisfy **both** to be instrumented. We'll instrument programs that:
+  - run from the `/app` or `/utilities` directories, or have an `.exe` extension (`include_paths`)
+  - **and** have a command line argument matching `*MyProject*.jar` or ending in `app.js` (`include_with_arguments`)
+  - however, even if both include conditions are met, the injector **will avoid** programs that have:
+    - a command line argument starting with `-javaagent:`
+    - a command line argument containing `@opentelemetry-js`
+    - a maximum memory argument matching `-Xmx?m` (single digit megabytes)
 
 The example above illustrates how we avoid telemetry from unwanted applications or
 injecting auto-instrumentation to programs that are already instrumented. If you have a
 standard way of deploying all of your applications, you can create a default `otelinject.conf`
 file that will ensure you get only the telemetry you want.
 
-The `include_paths`, `exclude_paths`, `include_with_arguments` and `exclude_with_arguments` settings in
-the configuration file are additive. This means that if you define multiple lines of these settings, the resulting
-patterns list will be a union of all of the settings. This allows for easier manipulation of the configuration
-file with automated tools. Essentially, you can list each include or exclude rule on a separate line.
+Multiple lines of the same setting are combined as a union (OR). This means that if you define multiple
+lines of `include_paths`, for example, the resulting patterns list will be a union of all of the lines.
+This allows for easier manipulation of the configuration file with automated tools. Essentially, you can
+list each pattern on a separate line. Note that different settings (e.g. `include_paths` and
+`include_with_arguments`) are ANDed together — a process must satisfy each configured include setting.
 For example, the following two configuration files have an identical outcome:
 ```
 include_paths=/app/*,/utilities/*,*.exe

--- a/src/patterns_matcher.zig
+++ b/src/patterns_matcher.zig
@@ -74,6 +74,35 @@ pub fn matchesManyAnyPattern(args: []const []const u8, patterns: []const []const
     return false;
 }
 
+/// Evaluates whether a process should be allowed based on include path and argument patterns.
+/// By default (no include constraints configured), all processes are allowed. Each non-empty include
+/// setting adds a condition: include_paths requires the exe path to match at least one pattern, and
+/// include_args requires at least one argument to match at least one pattern. All conditions must be
+/// met (AND across settings).
+pub fn evaluateAllow(
+    exe_path: []const u8,
+    args: []const []const u8,
+    include_paths: []const []const u8,
+    include_args: []const []const u8,
+) bool {
+    if (include_paths.len > 0 and !matchesAnyPattern(exe_path, include_paths)) return false;
+    if (include_args.len > 0 and !matchesManyAnyPattern(args, include_args)) return false;
+    return true;
+}
+
+/// Evaluates whether a process should be denied based on exclude path and argument patterns.
+/// Returns true if any exclude_paths pattern matches the exe path, or if any exclude_args pattern
+/// matches any argument. Returns false if no exclude constraints are configured.
+pub fn evaluateDeny(
+    exe_path: []const u8,
+    args: []const []const u8,
+    exclude_paths: []const []const u8,
+    exclude_args: []const []const u8,
+) bool {
+    return ((exclude_paths.len > 0) and matchesAnyPattern(exe_path, exclude_paths))
+        or ((exclude_args.len > 0) and matchesManyAnyPattern(args, exclude_args));
+}
+
 test "matchGlob: exact match" {
     try testing.expect(matchGlob("/usr/bin/bash", "/usr/bin/bash"));
     try testing.expect(!matchGlob("/usr/bin/bash", "/usr/bin/zsh"));
@@ -210,4 +239,60 @@ test "matchesManyAnyPattern: program name not matched" {
     const patterns: []const []const u8 = &.{"/usr/bin/myprogram"};
     const args: []const []const u8 = &.{ "/usr/bin/myprogram", "arg1" };
     try testing.expect(!matchesManyAnyPattern(args, patterns));
+}
+
+test "evaluateAllow: no includes configured allows all processes" {
+    const args: []const []const u8 = &.{"/usr/bin/bash"};
+    try testing.expect(evaluateAllow("/usr/bin/bash", args, &.{}, &.{}));
+    try testing.expect(evaluateAllow("/opt/myapp", args, &.{}, &.{}));
+}
+
+test "evaluateAllow: include_paths set without include_args, matching path is allowed" {
+    const include_paths: []const []const u8 = &.{"*/java"};
+    const args: []const []const u8 = &.{"/usr/bin/java"};
+    try testing.expect(evaluateAllow("/usr/bin/java", args, include_paths, &.{}));
+}
+
+test "evaluateAllow: include_paths set without include_args, non-matching path is denied" {
+    const include_paths: []const []const u8 = &.{"*/java"};
+    const args: []const []const u8 = &.{"/bin/sh"};
+    try testing.expect(!evaluateAllow("/bin/sh", args, include_paths, &.{}));
+}
+
+test "evaluateAllow: both set, both match, process is allowed" {
+    const include_paths: []const []const u8 = &.{"*/java"};
+    const include_args: []const []const u8 = &.{"-jar"};
+    const args: []const []const u8 = &.{ "/usr/bin/java", "-jar", "myapp.jar" };
+    try testing.expect(evaluateAllow("/usr/bin/java", args, include_paths, include_args));
+}
+
+test "evaluateAllow: both set, path matches but args do not, process is denied" {
+    const include_paths: []const []const u8 = &.{"*/java"};
+    const include_args: []const []const u8 = &.{"-jar"};
+    const args: []const []const u8 = &.{ "/usr/bin/java", "-verbose" };
+    try testing.expect(!evaluateAllow("/usr/bin/java", args, include_paths, include_args));
+}
+
+test "evaluateDeny: no excludes configured denies nothing" {
+    const args: []const []const u8 = &.{"/usr/bin/bash"};
+    try testing.expect(!evaluateDeny("/usr/bin/bash", args, &.{}, &.{}));
+    try testing.expect(!evaluateDeny("/opt/myapp", args, &.{}, &.{}));
+}
+
+test "evaluateDeny: exclude_paths set without exclude_args, matching path is denied" {
+    const exclude_paths: []const []const u8 = &.{"*/sh"};
+    const args: []const []const u8 = &.{"/bin/sh"};
+    try testing.expect(evaluateDeny("/bin/sh", args, exclude_paths, &.{}));
+}
+
+test "evaluateDeny: exclude_paths set without exclude_args, non-matching path is not denied" {
+    const exclude_paths: []const []const u8 = &.{"*/sh"};
+    const args: []const []const u8 = &.{"/usr/bin/java"};
+    try testing.expect(!evaluateDeny("/usr/bin/java", args, exclude_paths, &.{}));
+}
+
+test "evaluateDeny: exclude_args set without exclude_paths, matching arg is denied" {
+    const exclude_args: []const []const u8 = &.{"-debug"};
+    const args: []const []const u8 = &.{ "/usr/bin/java", "-debug" };
+    try testing.expect(evaluateDeny("/usr/bin/java", args, &.{}, exclude_args));
 }

--- a/src/patterns_matcher.zig
+++ b/src/patterns_matcher.zig
@@ -99,8 +99,7 @@ pub fn evaluateDeny(
     exclude_paths: []const []const u8,
     exclude_args: []const []const u8,
 ) bool {
-    return ((exclude_paths.len > 0) and matchesAnyPattern(exe_path, exclude_paths))
-        or ((exclude_args.len > 0) and matchesManyAnyPattern(args, exclude_args));
+    return ((exclude_paths.len > 0) and matchesAnyPattern(exe_path, exclude_paths)) or ((exclude_args.len > 0) and matchesManyAnyPattern(args, exclude_args));
 }
 
 test "matchGlob: exact match" {

--- a/src/root.zig
+++ b/src/root.zig
@@ -223,10 +223,8 @@ fn evaluateAllowDeny(allocator: std.mem.Allocator, configuration: config.Injecto
         allocator.free(args);
     }
 
-    var allow = (configuration.include_paths.len == 0) or pattern_matcher.matchesAnyPattern(exe_path, configuration.include_paths);
-    allow = allow or (configuration.include_args.len == 0) or pattern_matcher.matchesManyAnyPattern(args, configuration.include_args);
-    var deny = (configuration.exclude_paths.len > 0) and pattern_matcher.matchesAnyPattern(exe_path, configuration.exclude_paths);
-    deny = deny or ((configuration.exclude_args.len > 0) and pattern_matcher.matchesManyAnyPattern(args, configuration.exclude_args));
+    const allow = pattern_matcher.evaluateAllow(exe_path, args, configuration.include_paths, configuration.include_args);
+    const deny = pattern_matcher.evaluateDeny(exe_path, args, configuration.exclude_paths, configuration.exclude_args);
 
     if (!allow or deny) {
         print.printDebug("executable with path {s} ignored. allow={any}, deny={any}", .{ exe_path, allow, deny });


### PR DESCRIPTION
Fixes a bug where include_paths was ignored when include_with_arguments was not configured. Corrects the semantics so that each non-empty include setting adds a condition that must be satisfied independently (AND across settings, OR within). Extracts allow/deny evaluation into testable functions in patterns_matcher.zig and updates the README accordingly.