### PR TITLE
Filter processes before eval libc

### DIFF
--- a/.chloggen/filter-processes-before-eval-libc.yaml
+++ b/.chloggen/filter-processes-before-eval-libc.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: injector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Evaluate include/exclude process filters before attempting libc detection, eliminating spurious "failed to identify libc" warnings for filtered-out processes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [311]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/injector-integration-tests/common/otelinject.exclude-noenviron.conf
+++ b/injector-integration-tests/common/otelinject.exclude-noenviron.conf
@@ -1,0 +1,3 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+exclude_paths=*/noenviron

--- a/injector-integration-tests/runtimes/no-environ-symbol/Dockerfile
+++ b/injector-integration-tests/runtimes/no-environ-symbol/Dockerfile
@@ -28,6 +28,7 @@ COPY injector-integration-tests/scripts/run-tests-within-container.sh scripts/
 COPY injector-integration-tests/scripts/create-*.sh scripts/
 COPY injector-integration-tests/tests/*.tests tests/
 COPY injector-integration-tests/common/otelinject.conf otelinject.conf
+COPY injector-integration-tests/common/otelinject.exclude-noenviron.conf otelinject.exclude-noenviron.conf
 COPY injector-integration-tests/common/otelinject.custom-location.conf /custom/config/path/otelinject.conf
 COPY injector-integration-tests/common/default_auto_instrumentation_env.conf default_auto_instrumentation_env.conf
 

--- a/injector-integration-tests/scripts/run-tests-within-container.sh
+++ b/injector-integration-tests/scripts/run-tests-within-container.sh
@@ -56,6 +56,8 @@ fi
 #   code is zero and the app's output matches this string
 # - env_vars (optional): Set additional environment variables like NODE_OPTIONS or OTEL_RESOURCE_ATTRIBUTES when running
 #   the test
+# - expected_stderr (optional): If provided, the test will also assert that the process's stderr output matches this
+#   value exactly. If not provided, stderr is not checked.
 # shellcheck disable=SC2317
 run_test_case() {
   test_case_label=$1
@@ -63,6 +65,13 @@ run_test_case() {
   test_app_command=$3
   expected=$4
   env_vars=${5:-}
+  if [ $# -ge 6 ]; then
+    check_stderr=true
+    expected_stderr=$6
+  else
+    check_stderr=false
+    expected_stderr=""
+  fi
 
   if [ -n "${TEST_CASES:-}" ]; then
     # Only run test case if there is an _exact match_ for the test case label in the comma-separated list $TEST_CASES.
@@ -111,6 +120,14 @@ run_test_case() {
   fi
 
   set +e
+  match=$(expr "$test_case_label" : ".*include paths filter.*")
+  set -e
+  if [ "$match" -gt 0 ]; then
+    echo "providing include paths filter configuration file at /etc/opentelemetry/otelinject.conf for test case \"$test_case_label\""
+    cp otelinject.exclude-noenviron.conf /etc/opentelemetry/otelinject.conf
+  fi
+
+  set +e
   match=$(expr "$test_case_label" : ".*env file.*")
   set -e
   if [ "$match" -gt 0 ]; then
@@ -136,8 +153,17 @@ run_test_case() {
   fi
   full_command=" $full_command $test_app_command"
   set +e
-  test_output=$(eval "$full_command")
-  test_exit_code=$?
+  if [ "$check_stderr" = "true" ]; then
+    stderr_file=$(mktemp)
+    test_output=$(eval "$full_command" 2>"$stderr_file")
+    test_exit_code=$?
+    test_stderr=$(cat "$stderr_file")
+    rm -f "$stderr_file"
+  else
+    test_output=$(eval "$full_command")
+    test_exit_code=$?
+    test_stderr=""
+  fi
   cd "$home_directory"
   set -e
   if [ $test_exit_code != 0 ]; then
@@ -152,6 +178,13 @@ run_test_case() {
     echo "test command: $full_command"
     echo "expected: $expected"
     echo "actual:   $test_output"
+    echo "--- end of output"
+    exit_code=1
+  elif [ "$check_stderr" = "true" ] && [ "$test_stderr" != "$expected_stderr" ]; then
+    printf "${RED}test \"%s\" failed (stderr mismatch):${NC}\n" "$test_case_label"
+    echo "test command: $full_command"
+    echo "expected stderr: $expected_stderr"
+    echo "actual stderr:   $test_stderr"
     echo "--- end of output"
     exit_code=1
   else

--- a/injector-integration-tests/tests/no-environ-symbol.tests
+++ b/injector-integration-tests/tests/no-environ-symbol.tests
@@ -10,3 +10,15 @@ run_test_case \
   "./noenviron" \
   "The environment variable \"NO_ENVIRON_TEST_VAR\" had the value: \"some-value\"." \
   "NO_ENVIRON_TEST_VAR=some-value"
+
+# Verify that a process filtered out by include_paths produces no injector output on stderr.
+# The noenviron binary is a Go PIE binary with no libc — exactly the kind of process that
+# previously triggered "failed to identify libc" warnings before allow/deny filtering was
+# moved ahead of libc detection.
+run_test_case \
+  "include paths filter: filtered process produces no injector stderr output" \
+  "app" \
+  "./noenviron" \
+  "The environment variable \"NO_ENVIRON_TEST_VAR\" is not set." \
+  "" \
+  ""

--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,7 @@ const std = @import("std");
 const print = @import("print.zig");
 const test_util = @import("test_util.zig");
 const patterns_util = @import("patterns_util.zig");
+const proc_self_environ_parser = @import("proc_self_environ_parser.zig");
 
 const testing = std.testing;
 
@@ -102,20 +103,22 @@ var cached_configuration_optional: ?InjectorConfiguration = null;
 /// After reading the configuration file, the configuration will be merged with values read from environment variables
 /// (DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX, JVM_AUTO_INSTRUMENTATION_AGENT_PATH, etc.). Environment variables
 /// have higher precedence and can override settings from the configuration file.
-pub fn readConfiguration(allocator: std.mem.Allocator) InjectorConfiguration {
+pub fn readConfiguration(allocator: std.mem.Allocator, getenv_fn: proc_self_environ_parser.GetenvFn) InjectorConfiguration {
     if (cached_configuration_optional) |cached_configuration| {
         return cached_configuration;
     }
 
     var config_file_path: []const u8 = default_config_file_path;
-    if (std.posix.getenv(config_file_path_env_var)) |value| {
-        config_file_path = std.mem.trim(u8, value, " \t\r\n");
-        if (config_file_path.len == 0) {
-            config_file_path = default_config_file_path;
+    const env_config_path = getenv_fn(allocator, config_file_path_env_var);
+    defer if (env_config_path) |p| allocator.free(p);
+    if (env_config_path) |value| {
+        const trimmed = std.mem.trim(u8, value, " \t\r\n");
+        if (trimmed.len > 0) {
+            config_file_path = trimmed;
         }
     }
 
-    return readConfigurationFromPath(allocator, config_file_path) catch |err| {
+    return readConfigurationFromPath(allocator, config_file_path, getenv_fn) catch |err| {
         print.printError("Cannot allocate memory while parsing configuration: {t}", .{err});
         return createEmptyConfiguration(allocator);
     };
@@ -140,7 +143,7 @@ fn createEmptyConfiguration(allocator: std.mem.Allocator) InjectorConfiguration 
     };
 }
 
-fn readConfigurationFromPath(allocator: std.mem.Allocator, cfg_file_path: []const u8) std.mem.Allocator.Error!InjectorConfiguration {
+fn readConfigurationFromPath(allocator: std.mem.Allocator, cfg_file_path: []const u8, getenv_fn: proc_self_environ_parser.GetenvFn) std.mem.Allocator.Error!InjectorConfiguration {
     // We create a good amount of intermediate values - keys, values, comma-separated parts of strings, default config
     // values that might or might not be later overwritten, etc. It would tricky and error-prone to release each of
     // them individually at exactly the right time. Instead, we use an arena for all allocations (including the actual
@@ -153,7 +156,7 @@ fn readConfigurationFromPath(allocator: std.mem.Allocator, cfg_file_path: []cons
 
     var preliminary_configuration = try createDefaultConfiguration(arena_allocator);
     readConfigurationFile(arena_allocator, cfg_file_path, &preliminary_configuration);
-    readConfigurationFromEnvironment(arena_allocator, &preliminary_configuration);
+    readConfigurationFromEnvironment(arena_allocator, &preliminary_configuration, getenv_fn);
     readAllAgentsEnvFile(
         arena_allocator,
         preliminary_configuration.all_auto_instrumentation_agents_env_path,
@@ -178,15 +181,15 @@ test "readConfiguration: should cache configuration and return same instance on 
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
 
-    const config1 = readConfiguration(allocator);
-    const config2 = readConfiguration(allocator);
+    const config1 = readConfiguration(allocator, proc_self_environ_parser.posixGetenv);
+    const config2 = readConfiguration(allocator, proc_self_environ_parser.posixGetenv);
 
     // Compare the pointer values directly to ensure the caching worked
     try testing.expectEqual(@intFromPtr(config1.dotnet_auto_instrumentation_agent_path_prefix.ptr), @intFromPtr(config2.dotnet_auto_instrumentation_agent_path_prefix.ptr));
     try testing.expectEqual(@intFromPtr(config1.jvm_auto_instrumentation_agent_path.ptr), @intFromPtr(config2.jvm_auto_instrumentation_agent_path.ptr));
 }
 
-test "readConfiguration: should respect OTEL_INJECTOR_CONFIG_FILE environment variable" {
+test "readConfiguration: respects OTEL_INJECTOR_CONFIG_FILE environment variable" {
     const allocator = testing.allocator;
     defer {
         if (cached_configuration_optional) |*config| {
@@ -207,7 +210,33 @@ test "readConfiguration: should respect OTEL_INJECTOR_CONFIG_FILE environment va
     const original_environ = try test_util.setStdCEnviron(&[1][]const u8{env_string});
     defer test_util.resetStdCEnviron(original_environ);
 
-    const configuration = readConfiguration(allocator);
+    const configuration = readConfiguration(allocator, proc_self_environ_parser.posixGetenv);
+    // No separate deinit — cleanup is handled by the defer block above via cached_configuration_optional
+
+    try testing.expectEqualStrings(
+        "/custom/path/to/dotnet/instrumentation",
+        configuration.dotnet_auto_instrumentation_agent_path_prefix,
+    );
+    try testing.expectEqualStrings(
+        "/custom/path/to/jvm/javaagent.jar",
+        configuration.jvm_auto_instrumentation_agent_path,
+    );
+}
+
+test "readConfigurationFromPath: loads from the specified path" {
+    const allocator = testing.allocator;
+
+    const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd_path);
+    const absolute_path_to_config_file =
+        try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/config/all_values.conf" });
+    defer allocator.free(absolute_path_to_config_file);
+
+    const original_environ = try test_util.clearStdCEnviron();
+    defer test_util.resetStdCEnviron(original_environ);
+
+    var configuration = try readConfigurationFromPath(allocator, absolute_path_to_config_file, proc_self_environ_parser.posixGetenv);
+    defer configuration.deinit(allocator);
 
     try testing.expectEqualStrings(
         "/custom/path/to/dotnet/instrumentation",
@@ -225,7 +254,7 @@ test "readConfigurationFromPath: file does not exist, no environment variables" 
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
 
-    var configuration = try readConfigurationFromPath(allocator, @constCast("/does/not/exist"));
+    var configuration = try readConfigurationFromPath(allocator, @constCast("/does/not/exist"), proc_self_environ_parser.posixGetenv);
     defer configuration.deinit(allocator);
 
     try testing.expectEqualStrings(
@@ -274,7 +303,7 @@ test "readConfigurationFromPath: file does not exist, environment variables are 
     });
     defer test_util.resetStdCEnviron(original_environ);
 
-    var configuration = try readConfigurationFromPath(allocator, @constCast("/does/not/exist"));
+    var configuration = try readConfigurationFromPath(allocator, @constCast("/does/not/exist"), proc_self_environ_parser.posixGetenv);
     defer configuration.deinit(allocator);
 
     try testing.expectEqualStrings(
@@ -327,7 +356,7 @@ test "readConfigurationFromPath: all configuration values from file, no environm
     const original_environ = try test_util.clearStdCEnviron();
     defer test_util.resetStdCEnviron(original_environ);
 
-    var configuration = try readConfigurationFromPath(allocator, absolute_path_to_config_file);
+    var configuration = try readConfigurationFromPath(allocator, absolute_path_to_config_file, proc_self_environ_parser.posixGetenv);
     defer configuration.deinit(allocator);
 
     try testing.expectEqualStrings(
@@ -391,7 +420,7 @@ test "readConfigurationFromPath: override some configuration values from file wi
     });
     defer test_util.resetStdCEnviron(original_environ);
 
-    var configuration = try readConfigurationFromPath(allocator, absolute_path_to_config_file);
+    var configuration = try readConfigurationFromPath(allocator, absolute_path_to_config_file, proc_self_environ_parser.posixGetenv);
     defer configuration.deinit(allocator);
 
     try testing.expectEqualStrings(
@@ -1154,8 +1183,8 @@ test "parseLine: invalid line (line too long)" {
     try test_util.expectWithMessage(result == null, "parseLine(invalid line) returns null");
 }
 
-fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configuration: *InjectorConfiguration) void {
-    if (std.posix.getenv(dotnet_agent_path_prefix_env_var)) |value| {
+fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configuration: *InjectorConfiguration, getenv_fn: proc_self_environ_parser.GetenvFn) void {
+    if (getenv_fn(arena_allocator, dotnet_agent_path_prefix_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const dotnet_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1163,7 +1192,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
         };
         configuration.dotnet_auto_instrumentation_agent_path_prefix = dotnet_value;
     }
-    if (std.posix.getenv(jvm_agent_path_env_var)) |value| {
+    if (getenv_fn(arena_allocator, jvm_agent_path_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const jvm_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1171,7 +1200,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
         };
         configuration.jvm_auto_instrumentation_agent_path = jvm_value;
     }
-    if (std.posix.getenv(nodejs_agent_path_env_var)) |value| {
+    if (getenv_fn(arena_allocator, nodejs_agent_path_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const nodejs_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1179,7 +1208,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
         };
         configuration.nodejs_auto_instrumentation_agent_path = nodejs_value;
     }
-    if (std.posix.getenv(python_agent_path_prefix_env_var)) |value| {
+    if (getenv_fn(arena_allocator, python_agent_path_prefix_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const python_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1187,11 +1216,11 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
         };
         configuration.python_auto_instrumentation_agent_path_prefix = python_value;
     }
-    if (std.posix.getenv(auto_instrumentation_disabled_env_var)) |value| {
+    if (getenv_fn(arena_allocator, auto_instrumentation_disabled_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         applyAutoInstrumentationDisabledValue(trimmed_value, auto_instrumentation_disabled_env_var, configuration);
     }
-    if (std.posix.getenv(include_paths_env_var)) |value| {
+    if (getenv_fn(arena_allocator, include_paths_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const include_paths_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1202,7 +1231,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
             return;
         };
     }
-    if (std.posix.getenv(exclude_paths_env_var)) |value| {
+    if (getenv_fn(arena_allocator, exclude_paths_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const exclude_paths_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1213,7 +1242,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
             return;
         };
     }
-    if (std.posix.getenv(include_args_env_var)) |value| {
+    if (getenv_fn(arena_allocator, include_args_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const include_args_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1224,7 +1253,7 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
             return;
         };
     }
-    if (std.posix.getenv(exclude_args_env_var)) |value| {
+    if (getenv_fn(arena_allocator, exclude_args_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const exclude_args_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
             print.printError("Cannot allocate memory to read the injector configuration from the environment: {}", .{err});
@@ -1248,7 +1277,7 @@ test "readConfigurationFromEnvironment: empty environment values" {
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try testing.expectEqualStrings(
         default_dotnet_auto_instrumentation_agent_path_prefix,
@@ -1296,7 +1325,7 @@ test "readConfigurationFromEnvironment: all values" {
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try testing.expectEqualStrings(
         "/path/from/env/var/dotnet",
@@ -1345,7 +1374,7 @@ test "readConfigurationFromEnvironment: OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISAB
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try test_util.expectWithMessage(configuration.dotnet_instrumentation_disabled, "configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(configuration.jvm_instrumentation_disabled, "configuration.jvm_instrumentation_disabled");
@@ -1366,7 +1395,7 @@ test "readConfigurationFromEnvironment: OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISAB
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try test_util.expectWithMessage(!configuration.dotnet_instrumentation_disabled, "!configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.jvm_instrumentation_disabled, "!configuration.jvm_instrumentation_disabled");
@@ -1387,7 +1416,7 @@ test "readConfigurationFromEnvironment: OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISAB
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try test_util.expectWithMessage(configuration.dotnet_instrumentation_disabled, "configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(configuration.jvm_instrumentation_disabled, "configuration.jvm_instrumentation_disabled");
@@ -1408,7 +1437,7 @@ test "readConfigurationFromEnvironment: OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISAB
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try test_util.expectWithMessage(!configuration.dotnet_instrumentation_disabled, "!configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.jvm_instrumentation_disabled, "!configuration.jvm_instrumentation_disabled");
@@ -1427,7 +1456,7 @@ test "readConfigurationFromEnvironment: if OTEL_INJECTOR_AUTO_INSTRUMENTATION_DI
     defer test_util.resetStdCEnviron(original_environ);
 
     var configuration = try createDefaultConfiguration(arena_allocator);
-    readConfigurationFromEnvironment(arena_allocator, &configuration);
+    readConfigurationFromEnvironment(arena_allocator, &configuration, proc_self_environ_parser.posixGetenv);
 
     try test_util.expectWithMessage(!configuration.dotnet_instrumentation_disabled, "!configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.jvm_instrumentation_disabled, "!configuration.jvm_instrumentation_disabled");

--- a/src/proc_self_environ_parser.zig
+++ b/src/proc_self_environ_parser.zig
@@ -12,15 +12,68 @@ const testing = std.testing;
 
 const proc_self_environ_path = "/proc/self/environ";
 const otel_injector_log_level_env_var_name = "OTEL_INJECTOR_LOG_LEVEL";
-const otel_injector_log_level_environ_prefix = "OTEL_INJECTOR_LOG_LEVEL=";
 pub const otel_injector_disabled_env_var_name = "OTEL_INJECTOR_DISABLED";
-const otel_injector_disabled_env_var_prefix = "OTEL_INJECTOR_DISABLED=";
+
+const max_getenv_entry_length = 8192;
+const max_getenv_buffer_len = max_getenv_entry_length * 2;
+
+/// Function type for reading environment variables, abstracting over reading from
+/// /proc/self/environ (production) vs std.posix.getenv (tests).
+pub const GetenvFn = *const fn (allocator: std.mem.Allocator, name: []const u8) ?[]u8;
+
+/// Looks up an environment variable by reading /proc/self/environ directly,
+/// without depending on libc or std.posix.getenv.
+/// Returns an allocated copy of the value, or null if not found or on error.
+/// Errors are treated the same as a missing variable: if /proc/self/environ is
+/// unreadable, callers that rely on this function (e.g. for OTEL_INJECTOR_CONFIG_FILE)
+/// will silently fall back to their defaults. This is intentional — initFromProcSelfEnviron
+/// runs earlier and will have already surfaced any read failure at a higher log level.
+/// The caller is responsible for freeing the returned slice.
+pub fn getenv(allocator: std.mem.Allocator, name: []const u8) ?[]u8 {
+    return getenvFromFile(allocator, proc_self_environ_path, name) catch null;
+}
+
+/// Wraps std.posix.getenv with the GetenvFn signature for use in tests,
+/// where environment variables are set via setenv()/putenv() rather than
+/// being present in /proc/self/environ.
+pub fn posixGetenv(allocator: std.mem.Allocator, name: []const u8) ?[]u8 {
+    const val = std.posix.getenv(name) orelse return null;
+    return allocator.dupe(u8, val) catch unreachable;
+}
+
+fn getenvFromFile(allocator: std.mem.Allocator, path: []const u8, name: []const u8) !?[]u8 {
+    var environ_file = try std.fs.openFileAbsolute(path, .{});
+    defer environ_file.close();
+    var buf: [max_getenv_buffer_len]u8 = undefined;
+    var reader = environ_file.reader(&buf);
+    while (takeSentinelOrDiscardOverlyLongLine(&reader)) |environ_entry| {
+        if (matchEntry(environ_entry, name)) |value| {
+            return try allocator.dupe(u8, value);
+        }
+    } else |err| switch (err) {
+        error.EndOfStream => {
+            var last_buf: [max_getenv_entry_length]u8 = undefined;
+            const chars = reader.interface.readSliceShort(&last_buf) catch return null;
+            if (matchEntry(last_buf[0..chars], name)) |value| {
+                return try allocator.dupe(u8, value);
+            }
+        },
+        else => return err,
+    }
+    return null;
+}
+
+fn matchEntry(entry: []const u8, name: []const u8) ?[]const u8 {
+    if (entry.len <= name.len) return null;
+    if (!std.mem.startsWith(u8, entry, name)) return null;
+    if (entry[name.len] != '=') return null;
+    return entry[name.len + 1 ..];
+}
 
 /// Initializes a few selected configuration settings (injector disabled, log level) based on environment variables
-/// (OTEL_INJECTOR_DISABLED, OTEL_INJECTOR_LOG_LEVEL), by reading /proc/self/environ line by line. When reading
-/// environment variables later in the injector's life cycle, we will use the pointer to the __environ array after
-/// looking it up via libc.getLibCInfo(), but this pointer is not available during the injector's initialization phase
-/// yet, and we need to know some settings _before_ running libc.getLibCInfo().
+/// (OTEL_INJECTOR_DISABLED, OTEL_INJECTOR_LOG_LEVEL), by reading /proc/self/environ directly. This runs before
+/// libc detection, config file reading, and allow/deny filtering — all of which depend on these settings or must
+/// complete before libc is accessed. The __environ pointer from libc is not yet available at this stage.
 pub fn initFromProcSelfEnviron() !void {
     try initFromEnvironFile(proc_self_environ_path);
 }
@@ -36,58 +89,40 @@ fn initFromEnvironFile(self_environ_path: []const u8) !void {
         },
     });
 
-    var log_level_env_var_value: ?[]const u8 = null;
+    const allocator = std.heap.page_allocator;
 
-    var environ_file = try std.fs.openFileAbsolute(self_environ_path, .{});
-    defer environ_file.close();
-    const max_line_length = 256;
-    const max_buffer_len = max_line_length * 2;
-    var buf: [max_buffer_len]u8 = undefined;
-    var reader = environ_file.reader(&buf);
-    while (takeSentinelOrDiscardOverlyLongLine(&reader)) |environ_entry| {
-        if (environ_entry.len > max_line_length) {
-            continue;
-        }
-        if (std.mem.startsWith(u8, environ_entry, otel_injector_log_level_environ_prefix)) {
-            log_level_env_var_value = environ_entry[otel_injector_log_level_environ_prefix.len..environ_entry.len];
-            continue;
-        }
-        if (std.mem.startsWith(u8, environ_entry, otel_injector_disabled_env_var_prefix)) {
-            const otel_injector_disabled_env_var_value =
-                environ_entry[otel_injector_disabled_env_var_prefix.len..environ_entry.len];
-            proc_self_environ_values.setOtelInjectorDisabled(parseBooleanValue(otel_injector_disabled_env_var_value));
-            continue;
-        }
-    } else |err| switch (err) {
+    const log_level_value = getenvFromFile(allocator, self_environ_path, otel_injector_log_level_env_var_name) catch |err| switch (err) {
         error.ReadFailed => {
             print.printWarn("Failed to read {s}", .{self_environ_path});
             return;
         },
-        // if the file does not end with a 0 byte, we still need to parse the last entry
-        // (realistically this probably will not occur for /proc/self/environ)
-        error.EndOfStream => {
-            var buffer: [max_line_length]u8 = undefined;
-            const chars = reader.interface.readSliceShort(&buffer) catch 0;
-            const environ_entry = buffer[0..chars];
-            if (std.mem.startsWith(u8, environ_entry, otel_injector_log_level_environ_prefix)) {
-                log_level_env_var_value = environ_entry[otel_injector_log_level_environ_prefix.len..chars];
-            }
-        },
+        else => return err,
+    };
+    defer if (log_level_value) |v| allocator.free(v);
+
+    const disabled_value = getenvFromFile(allocator, self_environ_path, otel_injector_disabled_env_var_name) catch |err| switch (err) {
+        error.ReadFailed => null,
+        else => return err,
+    };
+    defer if (disabled_value) |v| allocator.free(v);
+
+    if (disabled_value) |v| {
+        proc_self_environ_values.setOtelInjectorDisabled(parseBooleanValue(v));
     }
 
-    if (log_level_env_var_value) |log_level_value| {
-        if (std.ascii.eqlIgnoreCase("debug", log_level_value)) {
+    if (log_level_value) |log_level| {
+        if (std.ascii.eqlIgnoreCase("debug", log_level)) {
             proc_self_environ_values.setLogLevel(.Debug);
-        } else if (std.ascii.eqlIgnoreCase("info", log_level_value)) {
+        } else if (std.ascii.eqlIgnoreCase("info", log_level)) {
             proc_self_environ_values.setLogLevel(.Info);
-        } else if (std.ascii.eqlIgnoreCase("warn", log_level_value)) {
+        } else if (std.ascii.eqlIgnoreCase("warn", log_level)) {
             proc_self_environ_values.setLogLevel(.Warn);
-        } else if (std.ascii.eqlIgnoreCase("error", log_level_value)) {
+        } else if (std.ascii.eqlIgnoreCase("error", log_level)) {
             proc_self_environ_values.setLogLevel(.Error);
-        } else if (std.ascii.eqlIgnoreCase("none", log_level_value)) {
+        } else if (std.ascii.eqlIgnoreCase("none", log_level)) {
             proc_self_environ_values.setLogLevel(.None);
         } else {
-            print.printError("unknown value for OTEL_INJECTOR_LOG_LEVEL: \"{s}\" -- valid log levels are \"debug\", \"info\", \"warn\", \"error\", \"none\".", .{log_level_value});
+            print.printError("unknown value for OTEL_INJECTOR_LOG_LEVEL: \"{s}\" -- valid log levels are \"debug\", \"info\", \"warn\", \"error\", \"none\".", .{log_level});
         }
     }
     print.printDebug("log level: {}", .{proc_self_environ_values.getLogLevel()});
@@ -293,4 +328,82 @@ test "parseBooleanValue: correctly identifies true and false values" {
     for (false_values) |value| {
         try testing.expect(!parseBooleanValue(value));
     }
+}
+
+fn resolveTestAssetPath(allocator: std.mem.Allocator, relative_path: []const u8) ![]u8 {
+    const cwd_path = try std.fs.cwd().realpathAlloc(allocator, ".");
+    defer allocator.free(cwd_path);
+    return std.fs.path.resolve(allocator, &.{ cwd_path, relative_path });
+}
+
+test "getenvFromFile: variable found at start of file" {
+    const allocator = testing.allocator;
+    const path = try resolveTestAssetPath(allocator, "unit-test-assets/proc-self-environ/environ-log-level-debug");
+    defer allocator.free(path);
+    const value = try getenvFromFile(allocator, path, "ENV_VAR_1");
+    defer if (value) |v| allocator.free(v);
+    try testing.expectEqualStrings("value_1", value.?);
+}
+
+test "getenvFromFile: variable found in middle of file" {
+    const allocator = testing.allocator;
+    const path = try resolveTestAssetPath(allocator, "unit-test-assets/proc-self-environ/environ-log-level-debug");
+    defer allocator.free(path);
+    const value = try getenvFromFile(allocator, path, "OTEL_INJECTOR_LOG_LEVEL");
+    defer if (value) |v| allocator.free(v);
+    try testing.expectEqualStrings("debug", value.?);
+}
+
+test "getenvFromFile: variable found at end of file" {
+    const allocator = testing.allocator;
+    const path = try resolveTestAssetPath(allocator, "unit-test-assets/proc-self-environ/environ-log-level-debug");
+    defer allocator.free(path);
+    const value = try getenvFromFile(allocator, path, "ENV_VAR_2");
+    defer if (value) |v| allocator.free(v);
+    try testing.expectEqualStrings("value_2", value.?);
+}
+
+test "getenvFromFile: variable not found returns null" {
+    const allocator = testing.allocator;
+    const path = try resolveTestAssetPath(allocator, "unit-test-assets/proc-self-environ/environ-log-level-debug");
+    defer allocator.free(path);
+    const value = try getenvFromFile(allocator, path, "DOES_NOT_EXIST");
+    try testing.expectEqual(null, value);
+}
+
+test "getenvFromFile: prefix of variable name does not match" {
+    const allocator = testing.allocator;
+    const path = try resolveTestAssetPath(allocator, "unit-test-assets/proc-self-environ/environ-log-level-debug");
+    defer allocator.free(path);
+    // "ENV_VAR" is a prefix of "ENV_VAR_1" and "ENV_VAR_2" but should not match either
+    const value = try getenvFromFile(allocator, path, "ENV_VAR");
+    try testing.expectEqual(null, value);
+}
+
+test "getenvFromFile: overlong entry is skipped, subsequent entries still found" {
+    const allocator = testing.allocator;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    {
+        const f = try tmp_dir.dir.createFile("environ", .{});
+        defer f.close();
+        // Write an entry strictly longer than max_getenv_entry_length to trigger StreamTooLong
+        try f.writeAll("OVERLONG_VAR=");
+        const chunk = [_]u8{'x'} ** 64;
+        var written: usize = 0;
+        while (written <= max_getenv_entry_length) {
+            const n = @min(chunk.len, max_getenv_entry_length + 1 - written);
+            try f.writeAll(chunk[0..n]);
+            written += n;
+        }
+        try f.writeAll(&[1]u8{0}); // null terminator
+        try f.writeAll("TARGET_VAR=found_after_overlong");
+        try f.writeAll(&[1]u8{0});
+    }
+    const path = try tmp_dir.dir.realpathAlloc(allocator, "environ");
+    defer allocator.free(path);
+
+    const value = try getenvFromFile(allocator, path, "TARGET_VAR");
+    defer if (value) |v| allocator.free(v);
+    try testing.expectEqualStrings("found_after_overlong", value.?);
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -55,6 +55,17 @@ fn initEnviron() callconv(.c) void {
         return;
     }
 
+    // Read config and evaluate allow/deny before libc detection, so that filtered-out
+    // processes never attempt libc detection and never emit libc-related warnings.
+    // config.readConfiguration uses proc_self_environ_parser.getenv internally, which
+    // reads /proc/self/environ directly without requiring libc.
+    var configuration = config.readConfiguration(allocator, proc_self_environ_parser.getenv);
+    defer configuration.deinit(allocator);
+
+    if (!evaluateAllowDeny(allocator, configuration)) {
+        return;
+    }
+
     const libc_info = libc.getLibCInfo(allocator) catch |err| {
         if (err == error.UnknownLibCFlavor) {
             print.printError("no libc found: {}", .{err});
@@ -77,13 +88,6 @@ fn initEnviron() callconv(.c) void {
         print.printError("initEnviron(): cannot update std.os.environ: {}; ", .{err});
         return;
     };
-
-    var configuration = config.readConfiguration(allocator);
-    defer configuration.deinit(allocator);
-
-    if (!evaluateAllowDeny(allocator, configuration)) {
-        return;
-    }
 
     const maybe_modified_resource_attributes = res_attrs.getModifiedOtelResourceAttributesValue(
         allocator,


### PR DESCRIPTION
Related to #311.

Processes filtered by include/exclude configuration were still triggering libc detection, producing spurious "failed to identify libc" warnings in the injector's stderr output. This PR moves config file reading and allow/deny evaluation ahead of libc detection. To support this reordering, environment variable lookups during config reading are done by reading /proc/self/environ directly rather than via std.posix.getenv, which depends on libc. Filtered processes now exit before libc detection is ever attempted. An integration test verifies that filtered processes produce no injector stderr output.

Fixes https://github.com/open-telemetry/opentelemetry-injector/issues/314