### PR TITLE
Fix libc detection failure on glibc < 2.34 systems (e.g. RHEL 8) for binaries that do not link libdl.so

### DIFF
--- a/.chloggen/rhel-libc-detection-warning.yaml
+++ b/.chloggen/rhel-libc-detection-warning.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: injector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix libc detection failure on glibc < 2.34 systems (e.g. RHEL 8) for binaries that do not link libdl.so
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [311]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  On glibc < 2.34 (e.g. RHEL 8 / glibc 2.28), `dlsym` is exported by `libdl.so` rather than
+  `libc.so` itself. Binaries that do not link `libdl.so` (such as `grep`, simple C utilities, and
+  many other system programs) would produce a `failed to identify libc` warning and receive no
+  instrumentation. The fix adds a fallback that looks up `setenv` and `__environ` directly from the
+  ELF symbol table when `dlsym` is not found, which succeeds for `libc.so` on all glibc versions.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -74,6 +74,11 @@ The approach taken by the OpenTelemetry injector is as follows:
       If this lookup is successful, we can use it to actually call the `dlsym` function (without declaring a direct
       dependency on it).
 * Finally, use `dlsym` to find the location of the `setenv` and the `__environ` symbol.
+  On glibc < 2.34 (e.g. RHEL 8, Debian Bullseye), `dlsym` is provided by `libdl.so` rather than `libc.so` itself.
+  If the binary does not link `libdl.so`, `dlsym` will not be found in the libc memory range.
+  In that case, the injector falls back to looking up `setenv` and `__environ` directly from the ELF symbol table of
+  the libc memory range, which works because both symbols are always exported directly by `libc.so` on all glibc
+  versions.
 * Use the `__environ` symbol to read the existing environment variables for the process.
 * Use `setenv` to set or modify the required environment variables (`NODE_OPTIONS`, `JAVA_TOOL_OPTIONS`,
   `OTEL_RESOURCE_ATTRIBUTES` etc.)
@@ -208,30 +213,14 @@ read via `getenv` by some runtimes, as explained above)?
 That would give us all the benefits of the `getenv` override approach (less environment variable pollution), without any
 of the drawbacks described in the section [export `getenv`](#export-getenv).
 
-There are two issues that make this particular strategy prohibitive:
-
-1. On most modern distributions, the actual libc file (say, `libc.so.6`) contains `getenv`, `setenv` etc. and also
-   `dlsym`.
-   However, on older distributions (Debian bullseye being one example), `dlsym` is actually provided by a separate file.
-   Nearly all of libc's functions are provided by `libc-2.31.so` or similar (which is symlinked as `libc.so.6`), but
-   that file does not contain the symbols `dlsym`, `dlopen` etc. Instead, these symbols are provided by `libdl-2.31.so`.
-   Most interesting binaries will link both, libc and libdl, but of course binaries can also only link libc, if they
-   do not depend on libdl at all.
-   The best thing the injector could do in this case is to stand down.
-   It will not crash the executable, since there is no linking error.
-   But since it wasn't able to find `dlsym`, it can also not lookup `__environ`, hence it has no knowledge of the
-   current environment, hence its `getenv` override will not be able to return any values for any environment variable.
-   Effectively, this would start the executable with an empty environment, which is not acceptable.
-   This could potentially be worked around by looking up `__environ` directly without using `dlsym`, or by falling back
-   to backfilling the environment by reading `/proc/self/environ`.
-   However, the next issue is even more severe.
-2. There can be shared objects that look up environment variables very early in the startup process, even before the
-   injector had a chance to run its initialization code.
-   A prominent example is OpenSSL, which is used by many runtimes and applications.
-   The OpenSSL code, when run on arm64 CPUS, reads `OPENSSL_armcap` (a capabilities bitmaks) before the injector's init
-   code runs, that is, before it even had the chance to find the `__environ pointer` and read the process environment.
-   This would lead to the injector reporting `OPENSSL_armcap=null` to OpenSSL, even if it is actually set.
-   Obviously, this is also not acceptable, hence exporting `getenv` is not a viable approach.
+There is an issue that makes this particular strategy prohibitive:
+there can be shared libraries that look up environment variables very early in the startup process, even before the
+injector had a chance to run its initialization code.
+A prominent example is OpenSSL, which is used by many runtimes and applications.
+The OpenSSL code, when run on arm64 CPUS, reads `OPENSSL_armcap` (a capabilities bitmask) before the injector's init
+code runs, that is, before it even had the chance to find the `__environ` pointer and read the process environment.
+This would lead to the injector reporting `OPENSSL_armcap=null` to OpenSSL, even if it is actually set.
+Obviously, this is also not acceptable, hence exporting `getenv` is not a viable approach.
 
 In the end, avoiding the risk of breaking assumptions about the environment is deemed much more critical than not adding
 irrelevant environment variables to the environment of all processes, which is effectively more an aesthetics concern.

--- a/injector-integration-tests/runtimes/no-libdl/Dockerfile
+++ b/injector-integration-tests/runtimes/no-libdl/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# debian:bullseye-slim ships glibc 2.31. On glibc < 2.34, dlsym is exported by
+# libdl.so, not by libc.so itself (the two were merged in glibc 2.34). The test
+# app is a plain C binary compiled without -ldl, so libdl.so never appears in
+# /proc/self/maps. This combination reproduces the libc-detection failure seen
+# on RHEL 8 and similar pre-glibc-2.34 systems when a binary does not link libdl.
+# TODO: pin to a specific digest once the test is green.
+ARG base_image_run="debian:bullseye-slim"
+FROM ${base_image_run}
+
+ARG injector_binary
+RUN if [ -z "$injector_binary" ]; then \
+      echo "Error: build argument injector_binary is required but not set."; \
+      exit 1; \
+    fi
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/opentelemetry/injector/conf.d && chmod -R 777 /etc/opentelemetry
+
+WORKDIR /usr/src/otel/injector
+
+COPY injector-integration-tests/runtimes/no-libdl/app.c .
+RUN mkdir -p app && gcc -o app/printenv app.c && rm app.c
+
+COPY injector-integration-tests/scripts/run-tests-within-container.sh scripts/
+COPY injector-integration-tests/scripts/create-*.sh scripts/
+COPY injector-integration-tests/tests/*.tests tests/
+COPY injector-integration-tests/common/injector.conf injector.conf
+COPY injector-integration-tests/common/injector.custom-location.conf /custom/config/path/injector.conf
+COPY injector-integration-tests/common/default_auto_instrumentation_env.conf default_auto_instrumentation_env.conf
+
+COPY dist/${injector_binary} /injector/libotelinject.so
+
+CMD ["scripts/run-tests-within-container.sh"]

--- a/injector-integration-tests/runtimes/no-libdl/Dockerfile
+++ b/injector-integration-tests/runtimes/no-libdl/Dockerfile
@@ -6,8 +6,7 @@
 # app is a plain C binary compiled without -ldl, so libdl.so never appears in
 # /proc/self/maps. This combination reproduces the libc-detection failure seen
 # on RHEL 8 and similar pre-glibc-2.34 systems when a binary does not link libdl.
-# TODO: pin to a specific digest once the test is green.
-ARG base_image_run="debian:bullseye-slim"
+ARG base_image_run="debian:bullseye-slim@sha256:0083feb8da4f624e3a0245e7752af2517d4b81d8b8db50c725644672a132a31b"
 FROM ${base_image_run}
 
 ARG injector_binary

--- a/injector-integration-tests/runtimes/no-libdl/app.c
+++ b/injector-integration-tests/runtimes/no-libdl/app.c
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// A minimal C program that prints the value of a named environment variable.
+// Deliberately uses only libc (stdio, stdlib) and is compiled without -ldl, so
+// libdl.so does not appear in /proc/self/maps at runtime. This reproduces the
+// scenario seen on RHEL 8 and any other pre-glibc-2.34 system where dlsym lives
+// in libdl.so (not in libc.so), and the binary under test does not link libdl.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "error: an environment variable name argument is required\n");
+        return 1;
+    }
+    const char *name = argv[1];
+    const char *value = getenv(name);
+    if (value == NULL) {
+        printf("%s: -", name);
+    } else {
+        printf("%s: %s", name, value);
+    }
+    return 0;
+}

--- a/injector-integration-tests/scripts/run-tests-for-container.sh
+++ b/injector-integration-tests/scripts/run-tests-for-container.sh
@@ -46,6 +46,9 @@ fi
 if [[ "$TEST_SET" = "python.tests" ]]; then
   runtime="python"
 fi
+if [[ "$TEST_SET" = "no-libdl.tests" ]]; then
+  runtime="no-libdl"
+fi
 
 # We also use the Node.js test app for non-runtime specific tests (e.g. injector-integration-tests/tests/default.tests
 # etc.), so this is the default Dockerfile.
@@ -91,6 +94,12 @@ case "$runtime" in
     base_image_run=golang:1.25.5-trixie
     # We do not provide a different base image depending on the libc flavor, the point of this test scenario is to test
     # an app that depends on no libc whatsoever, so the test is the same for LIBC=musl and LIBC=glibc.
+    ;;
+  "no-libdl")
+    dockerfile_name="injector-integration-tests/runtimes/no-libdl/Dockerfile"
+    base_image_run=debian:bullseye-slim
+    # We do not provide a different base image depending on the libc flavor: the tests themselves skip for LIBC=musl
+    # because musl uses a different libc-detection path that is not affected by this bug.
     ;;
   *)
     echo "Unknown runtime: $runtime"
@@ -155,8 +164,8 @@ docker run $docker_run_extra_options \
   --env LIBC_FLAVOR="$LIBC" \
   --env DOTNET_ARCH="$dotnet_arch" \
   --env TEST_SET="$TEST_SET" \
-  --env TEST_CASES="$TEST_CASES" \
-  --env TEST_CASES_CONTAINING="$TEST_CASES_CONTAINING" \
+  --env TEST_CASES="${TEST_CASES:-}" \
+  --env TEST_CASES_CONTAINING="${TEST_CASES_CONTAINING:-}" \
   --env VERBOSE="${VERBOSE:-}" \
   "$image_name" \
   $docker_run_extra_arguments

--- a/injector-integration-tests/tests/no-libdl.tests
+++ b/injector-integration-tests/tests/no-libdl.tests
@@ -1,0 +1,25 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression tests for libc detection on glibc < 2.34 systems without libdl.
+#
+# On glibc < 2.34 (e.g. RHEL 8 / glibc 2.28, Debian Bullseye / glibc 2.31),
+# dlsym is exported by libdl.so, not by libc.so itself.  The injector's second
+# pass over /proc/self/maps searches every mapped shared object for dlsym; if
+# the process did not link libdl.so, that search exhausts all candidates and
+# returns CannotFindLibcMemoryRange.
+#
+# These tests use a plain C binary compiled without -ldl, which is the
+# generalisation of the concrete failure observed for /usr/bin/grep on RHEL 8.
+
+# This test is only meaningful on glibc; musl uses a different detection path.
+if [ "${LIBC_FLAVOR:-}" != "glibc" ]; then
+  echo "Skipping no-libdl tests: these tests are glibc-specific (LIBC_FLAVOR=${LIBC_FLAVOR:-unset})"
+  return 0 2>/dev/null || true
+fi
+
+run_test_case \
+  "glibc without libdl: injects OTEL_RESOURCE_ATTRIBUTES" \
+  "app" \
+  "./printenv OTEL_RESOURCE_ATTRIBUTES" \
+  "OTEL_RESOURCE_ATTRIBUTES: k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app"

--- a/src/libc.zig
+++ b/src/libc.zig
@@ -1004,17 +1004,38 @@ fn tryToFindSymbolsInMemoryRange(
         return error.CannotOpenLibc;
     };
 
-    const dlsym_fn =
-        linker.lookup(types.DlSymFn, dlsym_function_name) orelse return error.CannotFindDlSymSymbol;
+    if (linker.lookup(types.DlSymFn, dlsym_function_name)) |dlsym_fn| {
+        // Preferred path: use dlsym with handle=null (RTLD_DEFAULT) to resolve symbols
+        // across all loaded libraries. Available on glibc >= 2.34 (where dlsym is in
+        // libc.so itself) and on any binary that links libdl.so.
+        const maybe_setenv_fn = dlsym_fn(null, setenv_function_name);
+        const maybe_environ_ptr = dlsym_fn(null, environ_symbol_name);
 
-    // look up the symbols we need from the current program (handle = null)
-    const maybe_setenv_fn = dlsym_fn(null, setenv_function_name);
-    const maybe_environ_ptr = dlsym_fn(null, environ_symbol_name);
+        const setenv_fn_ptr: types.SetenvFnPtr =
+            @ptrCast(@alignCast(maybe_setenv_fn orelse return error.CannotFindSetenvSymbol));
+        const environ_ptr: types.EnvironPtr =
+            @ptrCast(@alignCast(maybe_environ_ptr orelse return error.CannotFindEnvironSymbol));
 
-    const setenv_fn_ptr: types.SetenvFnPtr =
-        @ptrCast(@alignCast(maybe_setenv_fn orelse return error.CannotFindSetenvSymbol));
-    const environ_ptr: types.EnvironPtr =
-        @ptrCast(@alignCast(maybe_environ_ptr orelse return error.CannotFindEnvironSymbol));
+        return .{
+            .flavor = libc_name_and_flavor.flavor,
+            .name = libc_name_and_flavor.name,
+            .environ_ptr = environ_ptr,
+            .setenv_fn_ptr = setenv_fn_ptr,
+        };
+    }
+
+    // Fallback path for glibc < 2.34: on those versions dlsym is exported by libdl.so
+    // rather than libc.so. A binary that does not link libdl.so will not have
+    // libdl.so in its /proc/self/maps, so dlsym is unreachable via the second pass.
+    // Look up setenv and __environ directly from this library's ELF symbol table.
+    // Both symbols are exported by libc.so on all glibc versions, so the second pass
+    // will find them here when it reaches the libc.so range. Libraries that do not
+    // export these symbols (libpthread, ld-linux, etc.) return an error and the second
+    // pass simply moves on to the next candidate.
+    const setenv_fn_ptr = linker.lookup(types.SetenvFnPtr, setenv_function_name) orelse
+        return error.CannotFindSetenvSymbol;
+    const environ_ptr = linker.lookup(types.EnvironPtr, environ_symbol_name) orelse
+        return error.CannotFindEnvironSymbol;
 
     return .{
         .flavor = libc_name_and_flavor.flavor,

--- a/src/libc.zig
+++ b/src/libc.zig
@@ -1000,12 +1000,12 @@ fn tryToFindSymbolsInMemoryRange(
     start: usize,
     end: usize,
 ) !types.LibCInfo {
-    const linker = elf.ElfDynLib.open(start, end) catch |err| {
+    const elf_lib = elf.ElfDynLib.open(start, end) catch |err| {
         print.printWarn("cannot open libc mapped range {x}-{x} as ELF library: {}", .{ start, end, err });
         return error.CannotOpenLibc;
     };
 
-    if (linker.lookup(types.DlSymFn, dlsym_function_name)) |dlsym_fn| {
+    if (elf_lib.lookup(types.DlSymFn, dlsym_function_name)) |dlsym_fn| {
         // Preferred path: use dlsym with handle=null (RTLD_DEFAULT) to resolve symbols
         // across all loaded libraries. Available on glibc >= 2.34 (where dlsym is in
         // libc.so itself) and on any binary that links libdl.so.
@@ -1033,9 +1033,9 @@ fn tryToFindSymbolsInMemoryRange(
     // will find them here when it reaches the libc.so range. Libraries that do not
     // export these symbols (libpthread, ld-linux, etc.) return an error and the second
     // pass simply moves on to the next candidate.
-    const setenv_fn_ptr = linker.lookup(types.SetenvFnPtr, setenv_function_name) orelse
+    const setenv_fn_ptr = elf_lib.lookup(types.SetenvFnPtr, setenv_function_name) orelse
         return error.CannotFindSetenvSymbol;
-    const environ_ptr = linker.lookup(types.EnvironPtr, environ_symbol_name) orelse
+    const environ_ptr = elf_lib.lookup(types.EnvironPtr, environ_symbol_name) orelse
         return error.CannotFindEnvironSymbol;
 
     return .{

--- a/src/libc.zig
+++ b/src/libc.zig
@@ -33,7 +33,6 @@ const LibCError = error{
     CannotFindAtBase,
     CannotFindElfDynamicSymbolTableOffset,
     CannotFindElfDynamicSymbolTableSize,
-    CannotFindDlSymSymbol,
     CannotFindEnvironSymbol,
     CannotFindLibcMemoryRange,
     CannotFindSetenvSymbol,
@@ -992,8 +991,10 @@ test "pathLooksLikeSharedObject" {
     try test_util.expectWithMessage(!pathLooksLikeSharedObject("/some/path/libotelinject_arm64.so"), "!pathLooksLikeSharedObject(\"/some/path/libotelinject_arm64.so\")");
 }
 
-/// Reads the given memory range via elf.ElfDynLib.open and tries to lookup the dlsym function via elf.ElfDynLib#lookup.
-/// If that succeeds, proceeds to try to lookup the setenv function and the __environ symbol using dlsym.
+/// Reads the given memory range via elf.ElfDynLib.open and tries to look up setenv and __environ.
+/// Preferred path: find dlsym in the ELF and use it with handle=null (RTLD_DEFAULT) to resolve symbols across all
+/// loaded libraries. Fallback path for glibc < 2.34: dlsym lives in libdl.so, not libc.so, so if it is not found,
+/// look up setenv and __environ directly from the ELF symbol table instead.
 fn tryToFindSymbolsInMemoryRange(
     libc_name_and_flavor: LibCNameAndFlavor,
     start: usize,
@@ -1062,7 +1063,7 @@ fn mockFindSymbolsInMemoryRange(
             .setenv_fn_ptr = @ptrFromInt(end),
         };
     }
-    return error.CannotFindDlSymSymbol;
+    return error.CannotFindSetenvSymbol;
 }
 
 fn takeSentinelOrDiscardOverlyLongLine(reader: *std.fs.File.Reader) ![]u8 {


### PR DESCRIPTION
Resolves #311.

On glibc < 2.34 (e.g. RHEL 8 / glibc 2.28), `dlsym` is exported by `libdl.so` rather than `libc.so` itself. Binaries that do not link `libdl.so` (such as `grep`, simple C utilities, and many other system programs) would produce a `failed to identify libc` warning and receive no instrumentation. The fix adds a fallback that looks up `setenv` and `__environ` directly from the ELF symbol table when `dlsym` is not found, which succeeds for `libc.so` on all glibc versions.