### PR TITLE
ci(renovate): split auto-instrumentation updates into individual PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,13 @@
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["minor", "major", "patch", "digest"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": ["packaging/*.txt"],
+      "groupName": null,
+      "matchUpdateTypes": ["minor", "major", "patch"],
+      "schedule": ["before 8am on Monday"]
     }
   ],
   "labels": [


### PR DESCRIPTION
Generally, I am in favor of grouping renovate update PRs, but for updating the auto-instrumentation agents/SDK, I think it might be better to split them into individual PRs. For example, https://github.com/open-telemetry/opentelemetry-injector/pull/326 updates all three SDKs; the JVM and Node.js update seem fine, while the .NET update broke the packaging integration tests. It would be nice to be able to merge the Node.js and the JVM update, and investigate/fix the .NET update separately.