### PR TITLE
test(integration): remove unused file

### DIFF
--- a/injector-integration-tests/runtimes/python/otelinject-enable-python.conf
+++ b/injector-integration-tests/runtimes/python/otelinject-enable-python.conf
@@ -1,1 +1,0 @@
-python_auto_instrumentation_agent_path_prefix = /usr/lib/opentelemetry/python


### PR DESCRIPTION
With e70f7877edb448ab55ae5a54a4f2e60a0b13ee5c the file injector-integration-tests/runtimes/python/otelinject-enable-python.conf has become unused.