### PR TITLE
chore(dotnet): update to v1.15.0, additional deps/shared store optional

### DIFF
--- a/injector-integration-tests/scripts/create-sdk-dummy-files-dotnet-optional.sh
+++ b/injector-integration-tests/scripts/create-sdk-dummy-files-dotnet-optional.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+mkdir -p /usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps
+mkdir -p /usr/lib/opentelemetry/dotnet/musl/AdditionalDeps
+mkdir -p /usr/lib/opentelemetry/dotnet/glibc/store
+mkdir -p /usr/lib/opentelemetry/dotnet/musl/store

--- a/injector-integration-tests/scripts/create-sdk-dummy-files.sh
+++ b/injector-integration-tests/scripts/create-sdk-dummy-files.sh
@@ -14,10 +14,6 @@ touch /usr/lib/opentelemetry/dotnet/glibc/linux-x64/OpenTelemetry.AutoInstrument
 touch /usr/lib/opentelemetry/dotnet/glibc/linux-arm64/OpenTelemetry.AutoInstrumentation.Native.so
 touch /usr/lib/opentelemetry/dotnet/musl/linux-musl-x64/OpenTelemetry.AutoInstrumentation.Native.so
 touch /usr/lib/opentelemetry/dotnet/musl/linux-musl-arm64/OpenTelemetry.AutoInstrumentation.Native.so
-mkdir -p /usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps
-mkdir -p /usr/lib/opentelemetry/dotnet/musl/AdditionalDeps
-mkdir -p /usr/lib/opentelemetry/dotnet/glibc/store
-mkdir -p /usr/lib/opentelemetry/dotnet/musl/store
 mkdir -p /usr/lib/opentelemetry/dotnet/glibc/net
 mkdir -p /usr/lib/opentelemetry/dotnet/musl/net
 if [ -d no-op-startup-hook ]; then

--- a/injector-integration-tests/scripts/run-tests-within-container.sh
+++ b/injector-integration-tests/scripts/run-tests-within-container.sh
@@ -111,6 +111,16 @@ run_test_case() {
     fi
   fi
 
+  # Ensure each test starts from a clean state.
+  if [ -d /usr/lib/opentelemetry ] && [ -x /usr/lib/opentelemetry ]; then
+    # Only clean up /usr/lib/opentelemetry if it exists and is accessible (which might not be the case for example in the
+    # sdk-cannot-be-accessed.tests test set, where the tree is intentionally chmod-ed to be inaccessible).
+    rm -rf /usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps
+    rm -rf /usr/lib/opentelemetry/dotnet/musl/AdditionalDeps
+    rm -rf /usr/lib/opentelemetry/dotnet/glibc/store
+    rm -rf /usr/lib/opentelemetry/dotnet/musl/store
+  fi
+
   set +e
   match=$(expr "$test_case_label" : ".*default configuration file.*")
   set -e
@@ -147,6 +157,15 @@ run_test_case() {
   else
     echo "providing empty env file at /etc/opentelemetry/injector/default_env.conf for test case \"$test_case_label\""
     touch /etc/opentelemetry/injector/default_env.conf
+  fi
+
+  set +e
+  match1=$(expr "$test_case_label" : ".*the additional deps directory exists.*")
+  match2=$(expr "$test_case_label" : ".*the shared store directory exists.*")
+  set -e
+  if [ "$match1" -gt 0 ] || [ "$match2" -gt 0 ]; then
+    echo "creating .NET additional deps and shared store directories for test case \"$test_case_label\""
+    scripts/create-sdk-dummy-files-dotnet-optional.sh
   fi
 
   cd "$working_dir"

--- a/injector-integration-tests/tests/dotnet.tests
+++ b/injector-integration-tests/tests/dotnet.tests
@@ -7,6 +7,34 @@ run_test_case \
   "./dotnetapp coreclr-profiler-path" \
   "CORECLR_PROFILER_PATH: /usr/lib/opentelemetry/dotnet/${LIBC_FLAVOR}/${DOTNET_ARCH}/OpenTelemetry.AutoInstrumentation.Native.so"
 
+# DOTNET_ADDITIONAL_DEPS and DOTNET_SHARED_STORE are optional. By default these two directories are not created (see
+# scripts/create-sdk-dummy-files.sh), to reflect .NET SDK 1.15 no longer having these directories. However, when they do exist,
+# the associated environment variables are still added. This is due to the comment in
+# https://github.com/open-telemetry/opentelemetry-dotnet-instrumentation/releases/tag/v1.15.0-beta.1:
+# > DOTNET_ADDITIONAL_DEPS/DOTNET_SHARED_STORE
+# > These environment variables are no longer required [...]
+# > Removing them is not yet recommended, as re-implementation of this workaround may be necessary for future configurations.
+run_test_case \
+  "does not set DOTNET_ADDITIONAL_DEPS when the additional deps directory does not exist" \
+  "app" \
+  "./dotnetapp custom-env-var DOTNET_ADDITIONAL_DEPS" \
+  "DOTNET_ADDITIONAL_DEPS: -"
+run_test_case \
+  "does not set DOTNET_SHARED_STORE when the shared store directory does not exist" \
+  "app" \
+  "./dotnetapp custom-env-var DOTNET_SHARED_STORE" \
+  "DOTNET_SHARED_STORE: -"
+run_test_case \
+  "sets DOTNET_ADDITIONAL_DEPS when the additional deps directory exists" \
+  "app" \
+  "./dotnetapp custom-env-var DOTNET_ADDITIONAL_DEPS" \
+  "DOTNET_ADDITIONAL_DEPS: /usr/lib/opentelemetry/dotnet/${LIBC_FLAVOR}/AdditionalDeps"
+run_test_case \
+  "sets DOTNET_SHARED_STORE when the shared store directory exists" \
+  "app" \
+   "./dotnetapp custom-env-var DOTNET_SHARED_STORE" \
+  "DOTNET_SHARED_STORE: /usr/lib/opentelemetry/dotnet/${LIBC_FLAVOR}/store"
+
 # For test cases with the "default configuration file" substring in their label, run-tests-within-container.sh
 # will provide a configuration file in the default location (/etc/opentelemetry/injector/injector.conf).
 run_test_case \

--- a/packaging/dotnet-agent-release.txt
+++ b/packaging/dotnet-agent-release.txt
@@ -1,2 +1,2 @@
 # renovate: datasource=github-releases depName=open-telemetry/opentelemetry-dotnet-instrumentation
-v1.14.1
+v1.15.0

--- a/src/dotnet.zig
+++ b/src/dotnet.zig
@@ -17,15 +17,15 @@ pub const DotnetValues = struct {
     coreclr_enable_profiling: [:0]const u8,
     coreclr_profiler: [:0]const u8,
     coreclr_profiler_path: [:0]u8,
-    additional_deps: [:0]u8,
-    shared_store: [:0]u8,
+    additional_deps: ?[:0]u8,
+    shared_store: ?[:0]u8,
     startup_hooks: [:0]u8,
     otel_auto_home: [:0]u8,
 
     pub fn freeAll(self: DotnetValues, allocator: std.mem.Allocator) void {
         allocator.free(self.coreclr_profiler_path);
-        allocator.free(self.additional_deps);
-        allocator.free(self.shared_store);
+        if (self.additional_deps) |ad| allocator.free(ad);
+        if (self.shared_store) |ss| allocator.free(ss);
         allocator.free(self.startup_hooks);
         allocator.free(self.otel_auto_home);
     }
@@ -129,7 +129,7 @@ fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_in
     }
 
     if (libc_flavor) |libc_f| {
-        const dotnet_values = determineDotnetValues(
+        var dotnet_values = determineDotnetValues(
             gpa,
             dotnet_path_prefix,
             libc_f,
@@ -146,9 +146,7 @@ fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_in
 
         const paths_to_check = [_][:0]const u8{
             dotnet_values.coreclr_profiler_path,
-            dotnet_values.additional_deps,
             dotnet_values.otel_auto_home,
-            dotnet_values.shared_store,
             dotnet_values.startup_hooks,
         };
         for (paths_to_check) |p| {
@@ -162,6 +160,25 @@ fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_in
                 // free strings allocated in determineDotnetValues
                 dotnet_values.freeAll(gpa);
                 return null;
+            };
+        }
+
+        // DOTNET_ADDITIONAL_DEPS is optional: only add the env var if the additional deps directory exists, do not skip .NET
+        // injection if it does not exist.
+        if (dotnet_values.additional_deps) |additional_deps_path| {
+            std.fs.cwd().access(additional_deps_path, .{}) catch |err| {
+                print.printDebug("Not setting DOTNET_ADDITIONAL_DEPS because of an issue accessing {s}: {}", .{ additional_deps_path, err });
+                gpa.free(additional_deps_path);
+                dotnet_values.additional_deps = null;
+            };
+        }
+        // DOTNET_SHARED_STORE is optional: only add the env var if the additional deps directory exists, do not skip .NET
+        // injection if it does not exist.
+        if (dotnet_values.shared_store) |shared_store_path| {
+            std.fs.cwd().access(shared_store_path, .{}) catch |err| {
+                print.printDebug("Not setting DOTNET_SHARED_STORE because of an issue accessing {s}: {}", .{ shared_store_path, err });
+                gpa.free(shared_store_path);
+                dotnet_values.shared_store = null;
             };
         }
 
@@ -672,7 +689,7 @@ test "determineDotnetValues: should return values for glibc/x86_64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps",
-        dotnet_values.additional_deps,
+        dotnet_values.additional_deps orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc",
@@ -680,7 +697,7 @@ test "determineDotnetValues: should return values for glibc/x86_64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/store",
-        dotnet_values.shared_store,
+        dotnet_values.shared_store orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll",
@@ -717,7 +734,7 @@ test "determineDotnetValues: should return values for glibc/arm64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps",
-        dotnet_values.additional_deps,
+        dotnet_values.additional_deps orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc",
@@ -725,7 +742,7 @@ test "determineDotnetValues: should return values for glibc/arm64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/store",
-        dotnet_values.shared_store,
+        dotnet_values.shared_store orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/glibc/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll",
@@ -762,7 +779,7 @@ test "determineDotnetValues: should return values for musl/x86_64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/AdditionalDeps",
-        dotnet_values.additional_deps,
+        dotnet_values.additional_deps orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl",
@@ -770,7 +787,7 @@ test "determineDotnetValues: should return values for musl/x86_64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/store",
-        dotnet_values.shared_store,
+        dotnet_values.shared_store orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll",
@@ -807,7 +824,7 @@ test "determineDotnetValues: should return values for musl/arm64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/AdditionalDeps",
-        dotnet_values.additional_deps,
+        dotnet_values.additional_deps orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl",
@@ -815,7 +832,7 @@ test "determineDotnetValues: should return values for musl/arm64" {
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/store",
-        dotnet_values.shared_store,
+        dotnet_values.shared_store orelse return error.Unexpected,
     );
     try testing.expectEqualStrings(
         "/usr/lib/opentelemetry/dotnet/musl/net/OpenTelemetry.AutoInstrumentation.StartupHook.dll",

--- a/src/root.zig
+++ b/src/root.zig
@@ -357,11 +357,21 @@ fn getEnvValue(
         }
     } else if (std.mem.eql(u8, name, dotnet.dotnet_additional_deps_env_var_name)) {
         if (dotnet.getDotnetValues(allocator, configuration)) |v| {
-            return v.additional_deps;
+            if (v.additional_deps) |ad| {
+                return ad;
+            } else {
+                // No additional_deps available, return null to skip injection of DOTNET_ADDITIONAL_DEPS.
+                return null;
+            }
         }
     } else if (std.mem.eql(u8, name, dotnet.dotnet_shared_store_env_var_name)) {
         if (dotnet.getDotnetValues(allocator, configuration)) |v| {
-            return v.shared_store;
+            if (v.shared_store) |ss| {
+                return ss;
+            } else {
+                // No shared_store available, return null to skip injection of DOTNET_SHARED_STORE.
+                return null;
+            }
         }
     } else if (std.mem.eql(u8, name, dotnet.dotnet_startup_hooks_env_var_name)) {
         if (dotnet.getDotnetValues(allocator, configuration)) |v| {


### PR DESCRIPTION
* chore(deps): update dependency open-telemetry/opentelemetry-dotnet-instrumentation to v1.15.0
* fix(dotnet): make additional deps and shared store optional

The following four directories are no longer part of the latest opentelemetry-dotnet-instrumentation release (1.15):
* /usr/lib/opentelemetry/dotnet/glibc/AdditionalDeps
* /usr/lib/opentelemetry/dotnet/glibc/store
* /usr/lib/opentelemetry/dotnet/musl/AdditionalDeps
* /usr/lib/opentelemetry/dotnet/musl/store

We still retain support for the associated environment variables for now, following the recommendation in opentelemetry-dotnet-instrumentation's v1.15.0-beta.1 release notes:

> Removed:
> Support of Additional Dependencies workaround for assembly conflict
> resolution via environment variables
> DOTNET_ADDITIONAL_DEPS/DOTNET_SHARED_STORE
> These environment variables are no longer required to resolve assembly
> version conflicts for the majority of use cases. However, there is no
> operational harm in keeping them from your previous installation.
> Removing them is not yet recommended, as re-implementation of this
> workaround may be necessary for future configurations.