### PR TITLE
docs(readme): fix reference to default_env.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This method requires `root` privileges.
      or a comma-separated list of runtimes for which to disable auto-instrumentation, see
      [Disabling auto-instrumentation for all runtimes or specific runtimes](#disabling-auto-instrumentation-for-all-runtimes-or-specific-runtimes)
 
-3. (Optional) The default env agent configuration file `/etc/opentelemetry/default_auto_instrumentation_env.conf` is empty (use
+3. (Optional) The default env agent configuration file `/etc/opentelemetry/injector/default_env.conf` is empty (use
    `all_auto_instrumentation_agents_env_path` option to specify a different path). Environment variables added to this file
    will be passed to all agents' environments. **NOTE**: environment variables which do not start with `OTEL_` are
    ignored.


### PR DESCRIPTION
This is a follow-up to e70f7877edb448ab55ae5a54a4f2e60a0b13ee5c.