### PR TITLE
feat(dotnet): skip injection for unsupported runtime versions

### DIFF
--- a/.chloggen/20260608-skip-dotnet-injection-for-unsupported-runtimes.yaml
+++ b/.chloggen/20260608-skip-dotnet-injection-for-unsupported-runtimes.yaml
@@ -1,0 +1,5 @@
+change_type: bug_fix
+component: injection
+note: Skip .NET injection for unsupported runtime versions.
+issues: [360]
+change_logs: [user]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,8 +86,12 @@ The approach taken by the OpenTelemetry injector is as follows:
 
 For .NET, the injector applies an additional check before setting the profiler
 and startup-hook related environment variables. It resolves the target application and inspects the adjacent
-`*.deps.json` file when available, standing down only when the dependency graph already references
-`OpenTelemetry*` packages. This keeps the injector fail-open while still reducing the risk of double-instrumentation.
+`*.runtimeconfig.json` file when available, using `runtimeOptions.tfm` to decide
+whether the target is a compatible .NET application. It stands down when the application clearly
+targets an older framework, but missing, unreadable, malformed, or incomplete runtimeconfig files remain fail-open.
+Following that check, the injector also inspects the adjacent `*.deps.json` file when available
+and stands down only when the dependency graph already references `OpenTelemetry*` packages. This keeps the injector
+fail-open while still reducing the risk of double-instrumentation.
 
 If this sounds convoluted, and more complex than it should be, read on!
 The next section outlines which alternative approaches have been considered, and the shortcomings of each of them.

--- a/README.md
+++ b/README.md
@@ -147,10 +147,16 @@ Here is an overview of the modifications that the injector will apply:
     * Note that the injector will not append to existing environment variables but overwrite them unconditionally if
       they are already set.
       In contrast to other runtimes, .NET does not support adding multiple agents.
-    * To reduce the risk of double-instrumentation, the injector inspects the adjacent `*.deps.json` file of the
+    * The injector first inspects the adjacent `*.runtimeconfig.json` file of the target application when it is
+      available.
+    * The injector stands down if the specified runtime version does not target `net8.0` or later.
+    * If the `.runtimeconfig.json` file is missing, unreadable, malformed, or missing the expected fields, the
+      injector proceeds with additional .NET checks.
+    * To reduce the risk of double-instrumentation, the injector then inspects the adjacent `*.deps.json` file of the
       target application when it is available.
     * The injector stands down if that `.deps.json` file already references `OpenTelemetry*` packages.
-    * If the `.deps.json` file is missing, unreadable, or malformed, the injector proceeds with .NET injection.
+    * If the `.deps.json` file is missing, unreadable, malformed, or missing the expected fields, the
+      injector proceeds with .NET injection.
 * It inspects specific existing environment variables and populates `OTEL_RESOURCE_ATTRIBUTES` with additional resource
   attributes. These environment variables need to be set externally (for example by a Kubernetes operator with a mutating
   webhook on the pod spec template of the workload). If `OTEL_RESOURCE_ATTRIBUTES` is already set, the additional

--- a/src/dotnet.zig
+++ b/src/dotnet.zig
@@ -693,14 +693,14 @@ test "runtimeConfigTargetsModernDotnet: true for net9.0 Microsoft.NETCore.App" {
     try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: true for net10.0 future multi-digit major" {
+test "runtimeConfigTargetsModernDotnet: true for net11.0 future multi-digit major" {
     const content =
         \\{
         \\  "runtimeOptions": {
-        \\    "tfm": "net10.0",
+        \\    "tfm": "net11.0",
         \\    "framework": {
         \\      "name": "Microsoft.NETCore.App",
-        \\      "version": "10.0.0"
+        \\      "version": "11.0.0"
         \\    }
         \\  }
         \\}

--- a/src/dotnet.zig
+++ b/src/dotnet.zig
@@ -244,11 +244,9 @@ fn shouldInjectDotnet(allocator: std.mem.Allocator) bool {
         print.printDebug("Proceeding with the injection of the .NET OpenTelemetry instrumentation. Could not parse {s} safely: {}", .{ metadata_paths.runtimeconfig_path, err });
         return true;
     };
-    if (runtimeconfig_targets_modern_dotnet) |is_supported| {
-        if (!is_supported) {
-            print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because {s} does not target a supported .NET runtime.", .{metadata_paths.runtimeconfig_path});
-            return false;
-        }
+    if (!runtimeconfig_targets_modern_dotnet) {
+        print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because {s} does not target a supported .NET runtime.", .{metadata_paths.runtimeconfig_path});
+        return false;
     }
 
     const deps_content = readSmallTextFileAlloc(allocator, metadata_paths.deps_path) catch |err| {
@@ -372,34 +370,31 @@ fn jsonObjectKeyLooksLikeOpenTelemetryDependency(key: []const u8) bool {
     return std.mem.startsWith(u8, dependency_name, opentelemetry_dependency_prefix);
 }
 
-fn runtimeConfigTargetsModernDotnet(allocator: std.mem.Allocator, content: []const u8) !?bool {
+fn runtimeConfigTargetsModernDotnet(allocator: std.mem.Allocator, content: []const u8) !bool {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
     defer parsed.deinit();
 
     const root = switch (parsed.value) {
         .object => |obj| obj,
-        else => return null,
+        else => return true,
     };
 
-    const runtime_options_value = root.get("runtimeOptions") orelse return null;
+    const runtime_options_value = root.get("runtimeOptions") orelse return true;
     const runtime_options = switch (runtime_options_value) {
         .object => |obj| obj,
-        else => return null,
+        else => return true,
     };
 
-    const tfm = runtime_options.get("tfm") orelse return null;
+    const tfm = runtime_options.get("tfm") orelse return true;
     const tfm_str = switch (tfm) {
         .string => |str| str,
-        else => return null,
+        else => return true,
     };
 
-    const tfm_support = tfmTargetsModernDotnet(tfm_str) orelse return null;
-    if (!tfm_support) return false;
-
-    return true;
+    return tfmTargetsModernDotnet(tfm_str);
 }
 
-fn tfmTargetsModernDotnet(tfm: []const u8) ?bool {
+fn tfmTargetsModernDotnet(tfm: []const u8) bool {
     if (!std.mem.startsWith(u8, tfm, "net")) return false;
 
     const rest = tfm[3..];
@@ -407,11 +402,11 @@ fn tfmTargetsModernDotnet(tfm: []const u8) ?bool {
     // We MUST find a dot to ensure it's a major.minor modern layout (e.g., net8.0)
     // This immediately filters out legacy dotless TFMs like "net48" or "net472"
     const dot_index = std.mem.indexOfScalar(u8, rest, '.') orelse return false;
-    if (dot_index == 0) return null;
+    if (dot_index == 0) return false;
 
     // Extract just the major version up to the dot (e.g., "8" from "8.0-windows")
     const major_str = rest[0..dot_index];
-    const major = std.fmt.parseUnsigned(u32, major_str, 10) catch return null;
+    const major = std.fmt.parseUnsigned(u32, major_str, 10) catch return false;
 
     return major >= 8;
 }
@@ -631,7 +626,7 @@ test "runtimeConfigTargetsModernDotnet: true for net8.0 Microsoft.NETCore.App" {
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
 test "runtimeConfigTargetsModernDotnet: true for ASP.NET Core runtimeconfig" {
@@ -647,7 +642,7 @@ test "runtimeConfigTargetsModernDotnet: true for ASP.NET Core runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
 test "runtimeConfigTargetsModernDotnet: false for net7.0 runtimeconfig" {
@@ -663,10 +658,10 @@ test "runtimeConfigTargetsModernDotnet: false for net7.0 runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage(!(try runtimeConfigTargetsModernDotnet(testing.allocator, content) orelse return error.Unexpected), "runtimeconfig should not qualify");
+    try test_util.expectWithMessage(!(try runtimeConfigTargetsModernDotnet(testing.allocator, content)), "runtimeconfig should not qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: null for incomplete runtimeconfig" {
+test "runtimeConfigTargetsModernDotnet: true for incomplete runtimeconfig" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -675,7 +670,7 @@ test "runtimeConfigTargetsModernDotnet: null for incomplete runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) == null, "runtimeconfig should be treated as unknown");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig with no tfm should proceed with injection");
 }
 
 test "runtimeConfigTargetsModernDotnet: rejects malformed json" {
@@ -695,7 +690,7 @@ test "runtimeConfigTargetsModernDotnet: true for net9.0 Microsoft.NETCore.App" {
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
 test "runtimeConfigTargetsModernDotnet: true for net10.0 future multi-digit major" {
@@ -711,7 +706,7 @@ test "runtimeConfigTargetsModernDotnet: true for net10.0 future multi-digit majo
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
 test "runtimeConfigTargetsModernDotnet: true for OS-specific TFM net8.0-windows" {
@@ -727,7 +722,7 @@ test "runtimeConfigTargetsModernDotnet: true for OS-specific TFM net8.0-windows"
         \\}
     ;
 
-    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
 }
 
 test "depsJsonContainsOpenTelemetryDependency: false when no OpenTelemetry packages are present" {

--- a/src/dotnet.zig
+++ b/src/dotnet.zig
@@ -51,9 +51,11 @@ const DotnetError = error{
 
 const DotnetMetadataPaths = struct {
     deps_path: []u8,
+    runtimeconfig_path: []u8,
 
     fn freeAll(self: DotnetMetadataPaths, allocator: std.mem.Allocator) void {
         allocator.free(self.deps_path);
+        allocator.free(self.runtimeconfig_path);
     }
 };
 
@@ -232,6 +234,23 @@ fn shouldInjectDotnet(allocator: std.mem.Allocator) bool {
     };
     defer metadata_paths.freeAll(allocator);
 
+    const runtimeconfig_content = readSmallTextFileAlloc(allocator, metadata_paths.runtimeconfig_path) catch |err| {
+        print.printDebug("Proceeding with the injection of the .NET OpenTelemetry instrumentation. Could not read {s}: {}", .{ metadata_paths.runtimeconfig_path, err });
+        return true;
+    };
+    defer allocator.free(runtimeconfig_content);
+
+    const runtimeconfig_targets_modern_dotnet = runtimeConfigTargetsModernDotnet(allocator, runtimeconfig_content) catch |err| {
+        print.printDebug("Proceeding with the injection of the .NET OpenTelemetry instrumentation. Could not parse {s} safely: {}", .{ metadata_paths.runtimeconfig_path, err });
+        return true;
+    };
+    if (runtimeconfig_targets_modern_dotnet) |is_supported| {
+        if (!is_supported) {
+            print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because {s} does not target a supported .NET runtime.", .{metadata_paths.runtimeconfig_path});
+            return false;
+        }
+    }
+
     const deps_content = readSmallTextFileAlloc(allocator, metadata_paths.deps_path) catch |err| {
         print.printDebug("Proceeding with the injection of the .NET OpenTelemetry instrumentation. Could not read {s}: {}", .{ metadata_paths.deps_path, err });
         return true;
@@ -295,6 +314,7 @@ fn createDotnetMetadataPaths(allocator: std.mem.Allocator, app_path: []const u8)
 
     return .{
         .deps_path = try std.fmt.allocPrint(allocator, "{s}.deps.json", .{app_base_path}),
+        .runtimeconfig_path = try std.fmt.allocPrint(allocator, "{s}.runtimeconfig.json", .{app_base_path}),
     };
 }
 
@@ -352,11 +372,48 @@ fn jsonObjectKeyLooksLikeOpenTelemetryDependency(key: []const u8) bool {
     return std.mem.startsWith(u8, dependency_name, opentelemetry_dependency_prefix);
 }
 
-fn getJsonObject(value: std.json.Value) ?std.json.ObjectMap {
-    return switch (value) {
-        .object => |object| object,
-        else => null,
+fn runtimeConfigTargetsModernDotnet(allocator: std.mem.Allocator, content: []const u8) !?bool {
+    var parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
+    defer parsed.deinit();
+
+    const root = switch (parsed.value) {
+        .object => |obj| obj,
+        else => return null,
     };
+
+    const runtime_options_value = root.get("runtimeOptions") orelse return null;
+    const runtime_options = switch (runtime_options_value) {
+        .object => |obj| obj,
+        else => return null,
+    };
+
+    const tfm = runtime_options.get("tfm") orelse return null;
+    const tfm_str = switch (tfm) {
+        .string => |str| str,
+        else => return null,
+    };
+
+    const tfm_support = tfmTargetsModernDotnet(tfm_str) orelse return null;
+    if (!tfm_support) return false;
+
+    return true;
+}
+
+fn tfmTargetsModernDotnet(tfm: []const u8) ?bool {
+    if (!std.mem.startsWith(u8, tfm, "net")) return false;
+
+    const rest = tfm[3..];
+
+    // We MUST find a dot to ensure it's a major.minor modern layout (e.g., net8.0)
+    // This immediately filters out legacy dotless TFMs like "net48" or "net472"
+    const dot_index = std.mem.indexOfScalar(u8, rest, '.') orelse return false;
+    if (dot_index == 0) return null;
+
+    // Extract just the major version up to the dot (e.g., "8" from "8.0-windows")
+    const major_str = rest[0..dot_index];
+    const major = std.fmt.parseUnsigned(u32, major_str, 10) catch return null;
+
+    return major >= 8;
 }
 
 test "doGetDotnetValues: should return null value if the libc flavor has not been set" {
@@ -538,6 +595,17 @@ test "createDotnetMetadataPaths: managed dll path produces deps path" {
     defer metadata_paths.freeAll(allocator);
 
     try testing.expectEqualStrings("/app/MyApp.deps.json", metadata_paths.deps_path);
+    try testing.expectEqualStrings("/app/MyApp.runtimeconfig.json", metadata_paths.runtimeconfig_path);
+}
+
+test "createDotnetMetadataPaths: managed exe path produces runtimeconfig path" {
+    const allocator = testing.allocator;
+
+    const metadata_paths = try createDotnetMetadataPaths(allocator, "/app/MyApp.exe");
+    defer metadata_paths.freeAll(allocator);
+
+    try testing.expectEqualStrings("/app/MyApp.deps.json", metadata_paths.deps_path);
+    try testing.expectEqualStrings("/app/MyApp.runtimeconfig.json", metadata_paths.runtimeconfig_path);
 }
 
 test "createDotnetMetadataPaths: apphost path produces deps path" {
@@ -547,6 +615,119 @@ test "createDotnetMetadataPaths: apphost path produces deps path" {
     defer metadata_paths.freeAll(allocator);
 
     try testing.expectEqualStrings("/app/MyApp.deps.json", metadata_paths.deps_path);
+    try testing.expectEqualStrings("/app/MyApp.runtimeconfig.json", metadata_paths.runtimeconfig_path);
+}
+
+test "runtimeConfigTargetsModernDotnet: true for net8.0 Microsoft.NETCore.App" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net8.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "8.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+}
+
+test "runtimeConfigTargetsModernDotnet: true for ASP.NET Core runtimeconfig" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net8.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.AspNetCore.App",
+        \\      "version": "8.0.1"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+}
+
+test "runtimeConfigTargetsModernDotnet: false for net7.0 runtimeconfig" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net7.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "7.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage(!(try runtimeConfigTargetsModernDotnet(testing.allocator, content) orelse return error.Unexpected), "runtimeconfig should not qualify");
+}
+
+test "runtimeConfigTargetsModernDotnet: null for incomplete runtimeconfig" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "rollForward": "Major"
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) == null, "runtimeconfig should be treated as unknown");
+}
+
+test "runtimeConfigTargetsModernDotnet: rejects malformed json" {
+    try testing.expectError(error.UnexpectedEndOfInput, runtimeConfigTargetsModernDotnet(testing.allocator, "{"));
+}
+
+test "runtimeConfigTargetsModernDotnet: true for net9.0 Microsoft.NETCore.App" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net9.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "9.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+}
+
+test "runtimeConfigTargetsModernDotnet: true for net10.0 future multi-digit major" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net10.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "10.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
+}
+
+test "runtimeConfigTargetsModernDotnet: true for OS-specific TFM net8.0-windows" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net8.0-windows",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "8.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage((try runtimeConfigTargetsModernDotnet(testing.allocator, content)) orelse return error.Unexpected, "runtimeconfig should qualify");
 }
 
 test "depsJsonContainsOpenTelemetryDependency: false when no OpenTelemetry packages are present" {


### PR DESCRIPTION
Attempts to examine the `[application-name].runtimeconfig.json` and read the `tfm` ([target framework moniker](https://learn.microsoft.com/en-us/dotnet/standard/frameworks)) field. The .NET runtime uses this field to determine which API version the runtime should expose the application.

* When the `tfm` value is `net8.0` or higher, injection is allowed to move forward.
* Older `tfm` values like `netcoreapp3.1` will be rejected as eligible for injection.
* If the file or field are missing, the checks fail open.
