### PR TITLE
Add a build time option to configured allowed env var prefixes

### DIFF
--- a/.chloggen/20260618-allowed-env-var-prefix-override.yaml
+++ b/.chloggen/20260618-allowed-env-var-prefix-override.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: injector
+note: Add a build-time option to override which environment variable prefixes are accepted from `all_auto_instrumentation_agents_env_path`.
+issues: [351]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ See the page [Zig Learn](https://ziglang.org/learn/) for more information about 
 ### Makefile commands
 
 * `make zig-build` to build the injector binary locally on your machine
+  * Set a comma-separated list of allowed environment variable prefixes using `ALLOWED_ENV_VAR_PREFIXES`, e.g.: `OTEL_,CUSTOM_PREFIX_`, to allow additional env var prefixes in a custom build. Default value is `OTEL_`.
 * `make watch-zig-build` to continually rebuild the Zig sources on every change (requires [`fd`](https://github.com/sharkdp/fd) and [`entr`](https://github.com/eradman/entr) to be installed)
 * `make zig-unit-tests` to run the unit tests
 * `watch-zig-unit-tests` to continually run the Zig unit tests on every change (requires [`fd`](https://github.com/sharkdp/fd) and [`entr`](https://github.com/eradman/entr) to be installed)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 ARCH?=amd64
 VERSION?=0.0.0-dev
+ALLOWED_ENV_VAR_PREFIXES?=OTEL_
 INSTALL_DIR:=/usr/lib/opentelemetry/otelinject
 DIST_DIR_BINARY:=dist
 BINARY_NAME_PREFIX:=libotelinject
@@ -57,7 +58,7 @@ clean:
 	rm -rf so $(DIST_DIR_BINARY) $(DIST_DIR_PACKAGE) zig-out .zig-cache
 
 so/$(BINARY_NAME_NO_ARCH): so
-	zig build -Dcpu-arch=${ARCH} --prominent-compile-errors --summary none
+	zig build -Dcpu-arch=${ARCH} -Dallowed-env-var-prefixes='$(ALLOWED_ENV_VAR_PREFIXES)' --prominent-compile-errors --summary none
 
 $(DIST_TARGET): $(DIST_SRCS)
 	@echo building the injector binary for architecture $(ARCH)
@@ -71,7 +72,7 @@ $(DIST_TARGET): $(DIST_SRCS)
 	docker buildx build --platform linux/$(ARCH) --build-arg DOCKER_REPO=$(DOCKER_REPO) --build-arg ZIG_ARCHITECTURE=$$ZIG_ARCHITECTURE -o type=image,name=libotelinject-builder:$(ARCH),push=false .
 	docker rm -f libotelinject-builder 2>/dev/null || true
 	docker run -d --platform linux/$(ARCH) --name libotelinject-builder libotelinject-builder:$(ARCH) sleep inf
-	docker exec libotelinject-builder make ARCH=$(ARCH) SHELL=/bin/sh all
+	docker exec libotelinject-builder make ARCH=$(ARCH) ALLOWED_ENV_VAR_PREFIXES='$(ALLOWED_ENV_VAR_PREFIXES)' SHELL=/bin/sh all
 	docker cp libotelinject-builder:/libotelinject/so/$(BINARY_NAME_NO_ARCH) $(DIST_DIR_BINARY)/$(BINARY_NAME)
 	docker rm -f libotelinject-builder
 
@@ -141,7 +142,7 @@ check-zig-installed:
 .PHONY: zig-build
 zig-build: check-zig-installed
 	@mkdir -p so
-	@(zig build -Dcpu-arch=${ARCH} --prominent-compile-errors --summary none && echo $(shell date) build successful) || (echo $(shell date) build failed && exit 1)
+	@(zig build -Dcpu-arch=${ARCH} -Dallowed-env-var-prefixes='$(ALLOWED_ENV_VAR_PREFIXES)' --prominent-compile-errors --summary none && echo $(shell date) build successful) || (echo $(shell date) build failed && exit 1)
 
 .PHONY: watch-zig-build
 watch-zig-build: check-zig-installed
@@ -149,7 +150,7 @@ watch-zig-build: check-zig-installed
 
 .PHONY: zig-unit-tests
 zig-unit-tests: check-zig-installed
-	@(zig build test -Dcpu-arch=${ARCH} --prominent-compile-errors --summary none && echo $(shell date) tests successful) || (echo $(shell date) tests failed && exit 1)
+	@(zig build test -Dcpu-arch=${ARCH} -Dallowed-env-var-prefixes='$(ALLOWED_ENV_VAR_PREFIXES)' --prominent-compile-errors --summary none && echo $(shell date) tests successful) || (echo $(shell date) tests failed && exit 1)
 
 .PHONY: watch-zig-unit-tests
 watch-zig-unit-tests: check-zig-installed

--- a/README.md
+++ b/README.md
@@ -82,8 +82,9 @@ This method requires `root` privileges.
 
 3. (Optional) The default env agent configuration file `/etc/opentelemetry/injector/default_env.conf` is empty (use
    `all_auto_instrumentation_agents_env_path` option to specify a different path). Environment variables added to this file
-   will be passed to all agents' environments. **NOTE**: environment variables which do not start with `OTEL_` are
-   ignored.
+   will be passed to all agents' environments. **NOTE**: by default, environment variables which do not start with
+   `OTEL_` are ignored. If you need to allow additional prefixes in a custom build, compile the injector with
+   `zig build -Dallowed-env-var-prefixes=OTEL_,CUSTOM_PREFIX_`. This setting is build-time only.
 
    The `auto_instrumentation_env.conf` file format is the same as other configurations:
 

--- a/build.zig
+++ b/build.zig
@@ -9,6 +9,11 @@ const std = @import("std");
 pub fn build(b: *std.Build) !void {
     const optimize = std.builtin.OptimizeMode.ReleaseSafe;
     const target_cpu = b.option(SupportedCpuArch, "cpu-arch", "The system architecture to compile the injector for; valid options are 'amd64' and 'arm64' (default)") orelse .arm64;
+    const allowed_env_var_prefixes = b.option(
+        []const u8,
+        "allowed-env-var-prefixes",
+        "Comma-separated env var prefixes allowed in the file pointed by all_auto_instrumentation_agents_env_path (default: OTEL_)",
+    ) orelse "OTEL_";
 
     const target = b.resolveTargetQuery(.{
         .cpu_arch = target_cpu.arch(),
@@ -34,6 +39,13 @@ pub fn build(b: *std.Build) !void {
         // Avoid a dependency from `__tls_get_addr` when compiling for x86
         .single_threaded = true,
     });
+    const build_options = b.addOptions();
+    build_options.addOption(
+        []const u8,
+        "allowed_env_var_prefixes",
+        allowed_env_var_prefixes,
+    );
+    lib_mod.addOptions("build_options", build_options);
 
     // Create a dynamically linked library based on the module created above.
     // This creates a `std.Build.Step.Compile`, which is the build step responsible
@@ -78,6 +90,7 @@ pub fn build(b: *std.Build) !void {
         .pic = true,
         .strip = false,
     });
+    test_mod.addOptions("build_options", build_options);
     const unit_tests = b.addTest(.{
         .root_module = test_mod,
         .filters = test_filters orelse &.{},

--- a/src/config.zig
+++ b/src/config.zig
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 const std = @import("std");
+const build_options = @import("build_options");
 
 const print = @import("print.zig");
 const test_util = @import("test_util.zig");
@@ -14,7 +15,7 @@ const default_config_file_path = "/etc/opentelemetry/injector/injector.conf";
 const config_file_path_env_var = "OTEL_INJECTOR_CONFIG_FILE";
 const max_line_length = 8192;
 const empty_string = @constCast("");
-const otel_env_var_prefix = "OTEL_";
+const allowed_env_var_prefixes = build_options.allowed_env_var_prefixes;
 
 // Agent paths are empty by default; they are enabled by installing conf.d drop-in files from the
 // respective language packages (e.g., opentelemetry-java-autoinstrumentation installs java.conf).
@@ -636,13 +637,34 @@ fn readConfigurationDirectory(arena_allocator: std.mem.Allocator, configuration:
 }
 
 fn applyKeyValueToAllAgentsEnv(_: std.mem.Allocator, key: []const u8, value: []u8, _file_path: []const u8, _configuration: *InjectorConfiguration) void {
-    if (!std.mem.startsWith(u8, key, otel_env_var_prefix)) {
-        print.printWarn("environment variable {s} does not start with {s}. ignoring.", .{ key, otel_env_var_prefix });
+    if (!isAllowedEnvVarKey(key)) {
+        print.printWarn(
+            "environment variable {s} does not match any allowed prefix from this build ({s}). ignoring.",
+            .{ key, allowed_env_var_prefixes },
+        );
         return;
     }
     _configuration.all_auto_instrumentation_agents_env_vars.put(key, value) catch |e| {
         print.printError("error storing environment variable {s} from file {s}: {}", .{ key, _file_path, e });
     };
+}
+
+fn isAllowedEnvVarKey(key: []const u8) bool {
+    return hasAllowedPrefix(key, allowed_env_var_prefixes);
+}
+
+fn hasAllowedPrefix(key: []const u8, prefixes_csv: []const u8) bool {
+    var prefixes = std.mem.splitScalar(u8, prefixes_csv, ',');
+    while (prefixes.next()) |raw_prefix| {
+        const prefix = std.mem.trim(u8, raw_prefix, " \t\r\n");
+        if (prefix.len == 0) {
+            continue;
+        }
+        if (std.mem.startsWith(u8, key, prefix)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn readAllAgentsEnvFile(arena_allocator: std.mem.Allocator, env_file_path: []const u8, configuration: *InjectorConfiguration) void {
@@ -1031,6 +1053,72 @@ test "readConfigurationFile: multiple auto_instrumentation_disabled line: last o
     try test_util.expectWithMessage(configuration.jvm_instrumentation_disabled, "configuration.jvm_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.nodejs_instrumentation_disabled, "!configuration.nodejs_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.python_instrumentation_disabled, "!configuration.python_instrumentation_disabled");
+}
+
+test "hasAllowedPrefix: default OTEL_ prefix only" {
+    try test_util.expectWithMessage(
+        hasAllowedPrefix("OTEL_SDK_DISABLED", "OTEL_"),
+        "OTEL_SDK_DISABLED should match OTEL_",
+    );
+    try test_util.expectWithMessage(
+        !hasAllowedPrefix("CUSTOM_PREFIX_ACCESS_TOKEN", "OTEL_"),
+        "CUSTOM_PREFIX_ACCESS_TOKEN should not match OTEL_",
+    );
+}
+
+test "hasAllowedPrefix: supports multiple prefixes and whitespace" {
+    try test_util.expectWithMessage(
+        hasAllowedPrefix("OTEL_SDK_DISABLED", " OTEL_ , CUSTOM_PREFIX_ ,, VENDOR_ "),
+        "OTEL_SDK_DISABLED should match OTEL_",
+    );
+    try test_util.expectWithMessage(
+        hasAllowedPrefix("CUSTOM_PREFIX_ACCESS_TOKEN", " OTEL_ , CUSTOM_PREFIX_ ,, VENDOR_ "),
+        "CUSTOM_PREFIX_ACCESS_TOKEN should match CUSTOM_PREFIX_",
+    );
+    try test_util.expectWithMessage(
+        hasAllowedPrefix("VENDOR_TRACE_MODE", " OTEL_ , CUSTOM_PREFIX_ ,, VENDOR_ "),
+        "VENDOR_TRACE_MODE should match VENDOR_",
+    );
+    try test_util.expectWithMessage(
+        !hasAllowedPrefix("PATH", " OTEL_ , CUSTOM_PREFIX_ ,, VENDOR_ "),
+        "PATH should not match any configured prefix",
+    );
+}
+
+test "readAllAgentsEnvFile: stores only variables matching allowed prefixes" {
+    const allocator = testing.allocator;
+
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    {
+        const file = try tmp_dir.dir.createFile("default_env.conf", .{});
+        defer file.close();
+        try file.writeAll(
+            \\OTEL_SDK_DISABLED=true
+            \\CUSTOM_PREFIX_ACCESS_TOKEN=secret
+            \\
+        );
+    }
+
+    const absolute_path_to_env_file = try tmp_dir.dir.realpathAlloc(allocator, "default_env.conf");
+    defer allocator.free(absolute_path_to_env_file);
+
+    var arena = std.heap.ArenaAllocator.init(allocator);
+    defer arena.deinit();
+    const arena_allocator = arena.allocator();
+
+    var configuration = try createDefaultConfiguration(arena_allocator);
+    readAllAgentsEnvFile(arena_allocator, absolute_path_to_env_file, &configuration);
+
+    try testing.expectEqual(1, configuration.all_auto_instrumentation_agents_env_vars.count());
+    try testing.expectEqualStrings(
+        "true",
+        configuration.all_auto_instrumentation_agents_env_vars.get("OTEL_SDK_DISABLED").?,
+    );
+    try test_util.expectWithMessage(
+        configuration.all_auto_instrumentation_agents_env_vars.get("CUSTOM_PREFIX_ACCESS_TOKEN") == null,
+        "CUSTOM_PREFIX_ACCESS_TOKEN should not be loaded by the default build",
+    );
 }
 
 /// Parses a single line from a configuration file.

--- a/src/config.zig
+++ b/src/config.zig
@@ -1086,6 +1086,32 @@ test "hasAllowedPrefix: supports multiple prefixes and whitespace" {
 }
 
 test "readAllAgentsEnvFile: stores only variables matching allowed prefixes" {
+    // Derive the sample keys from the build's configured allowed prefixes so this test
+    // stays correct regardless of the -Dallowed-env-var-prefixes value it was built with.
+    const allowed_key = comptime blk: {
+        var prefixes = std.mem.splitScalar(u8, build_options.allowed_env_var_prefixes, ',');
+        while (prefixes.next()) |raw_prefix| {
+            const prefix = std.mem.trim(u8, raw_prefix, " \t\r\n");
+            if (prefix.len == 0) continue;
+            break :blk prefix ++ "TEST_ALLOWED_KEY";
+        }
+        @compileError("build has no non-empty allowed_env_var_prefixes");
+    };
+    const disallowed_key = comptime blk: {
+        // Pick a sentinel key that provably does not match any configured prefix.
+        const candidates = [_][]const u8{
+            "ZZZ_TEST_DISALLOWED_KEY",
+            "QQQ_TEST_DISALLOWED_KEY",
+            "JJJ_TEST_DISALLOWED_KEY",
+        };
+        for (candidates) |c| {
+            if (!hasAllowedPrefix(c, build_options.allowed_env_var_prefixes)) {
+                break :blk c;
+            }
+        }
+        @compileError("could not find a sentinel disallowed key for this build's allowed_env_var_prefixes");
+    };
+
     const allocator = testing.allocator;
 
     var tmp_dir = testing.tmpDir(.{});
@@ -1093,11 +1119,7 @@ test "readAllAgentsEnvFile: stores only variables matching allowed prefixes" {
     {
         const file = try tmp_dir.dir.createFile("default_env.conf", .{});
         defer file.close();
-        try file.writeAll(
-            \\OTEL_SDK_DISABLED=true
-            \\CUSTOM_PREFIX_ACCESS_TOKEN=secret
-            \\
-        );
+        try file.writeAll(allowed_key ++ "=allowed-value\n" ++ disallowed_key ++ "=disallowed-value\n");
     }
 
     const absolute_path_to_env_file = try tmp_dir.dir.realpathAlloc(allocator, "default_env.conf");
@@ -1112,12 +1134,12 @@ test "readAllAgentsEnvFile: stores only variables matching allowed prefixes" {
 
     try testing.expectEqual(1, configuration.all_auto_instrumentation_agents_env_vars.count());
     try testing.expectEqualStrings(
-        "true",
-        configuration.all_auto_instrumentation_agents_env_vars.get("OTEL_SDK_DISABLED").?,
+        "allowed-value",
+        configuration.all_auto_instrumentation_agents_env_vars.get(allowed_key).?,
     );
     try test_util.expectWithMessage(
-        configuration.all_auto_instrumentation_agents_env_vars.get("CUSTOM_PREFIX_ACCESS_TOKEN") == null,
-        "CUSTOM_PREFIX_ACCESS_TOKEN should not be loaded by the default build",
+        configuration.all_auto_instrumentation_agents_env_vars.get(disallowed_key) == null,
+        "key with disallowed prefix should not be loaded",
     );
 }
 


### PR DESCRIPTION
Per meeting conversation, this PR adds a compile time option to add custom environment variable prefixes at build time.

Fix #351 