### PR TITLE
fix(injector): silently fall back to defaults when /proc/self/environ is unreadable (#361)

### DIFF
--- a/.chloggen/fix-361-access-denied-environ.yaml
+++ b/.chloggen/fix-361-access-denied-environ.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: injector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Silently fall back to defaults when `/proc/self/environ` is unreadable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [361]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When the host process drops privileges before the injector runs (e.g. a package
+  postinst script that switches to a service user before starting a daemon), opening
+  `/proc/self/environ` fails with `AccessDenied`. This previously bubbled up as an
+  error-level log entry in the host process's own log stream. The injector now
+  treats `AccessDenied` the same as any other read failure and silently falls back
+  to the default log level and disabled state.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/src/proc_self_environ_parser.zig
+++ b/src/proc_self_environ_parser.zig
@@ -92,7 +92,10 @@ fn initFromEnvironFile(self_environ_path: []const u8) !void {
     const allocator = std.heap.page_allocator;
 
     const log_level_value = getenvFromFile(allocator, self_environ_path, otel_injector_log_level_env_var_name) catch |err| switch (err) {
-        error.ReadFailed => {
+        // AccessDenied happens when the host process has dropped privileges before the injector runs
+        // (e.g. a package postinst script that switches to a service user before starting a daemon).
+        // Both errors mean the same thing here: we cannot read /proc/self/environ, so we fall back to defaults.
+        error.ReadFailed, error.AccessDenied => {
             print.printWarn("Failed to read {s}", .{self_environ_path});
             return;
         },
@@ -101,7 +104,7 @@ fn initFromEnvironFile(self_environ_path: []const u8) !void {
     defer if (log_level_value) |v| allocator.free(v);
 
     const disabled_value = getenvFromFile(allocator, self_environ_path, otel_injector_disabled_env_var_name) catch |err| switch (err) {
-        error.ReadFailed => null,
+        error.ReadFailed, error.AccessDenied => null,
         else => return err,
     };
     defer if (disabled_value) |v| allocator.free(v);
@@ -297,6 +300,35 @@ test "initFromEnvironFile: both OTEL_INJECTOR_LOG_LEVEL and OTEL_INJECTOR_DISABL
         try testing.expectEqual(true, proc_self_environ_values.getOtelInjectorDisabled());
         proc_self_environ_values.reset();
     }
+}
+
+test "initFromEnvironFile: unreadable environ file falls back to defaults" {
+    // Skip when running as root: chmod 0 does not prevent root from reading the file,
+    // so we cannot exercise the AccessDenied path.
+    if (builtin.target.os.tag == .linux and std.os.linux.geteuid() == 0) return;
+    if (builtin.target.os.tag == .macos and std.c.geteuid() == 0) return;
+
+    defer proc_self_environ_values.reset();
+    const allocator = testing.allocator;
+    var tmp_dir = testing.tmpDir(.{});
+    defer tmp_dir.cleanup();
+    {
+        const f = try tmp_dir.dir.createFile("environ-restricted", .{});
+        try f.writeAll("OTEL_INJECTOR_LOG_LEVEL=debug\x00OTEL_INJECTOR_DISABLED=true\x00");
+        f.close();
+    }
+    const path = try tmp_dir.dir.realpathAlloc(allocator, "environ-restricted");
+    defer allocator.free(path);
+    // Make the file unreadable to trigger AccessDenied when opening it.
+    try std.posix.fchmodat(std.posix.AT.FDCWD, path, 0o000, 0);
+    // Restore permissions on the way out so tmpDir cleanup succeeds.
+    defer std.posix.fchmodat(std.posix.AT.FDCWD, path, 0o600, 0) catch {};
+
+    // Must return without an error so the caller does not log at Error level.
+    try initFromEnvironFile(path);
+    // Defaults must be used since the file was unreadable.
+    try testing.expectEqual(.Error, proc_self_environ_values.getLogLevel());
+    try testing.expectEqual(false, proc_self_environ_values.getOtelInjectorDisabled());
 }
 
 test "initFromEnvironFile: overly long environment variable" {


### PR DESCRIPTION
When the host process drops privileges before the injector runs (e.g. a package postinst script that switches to a service user before starting a daemon), opening `/proc/self/environ` fails with `AccessDenied`. This previously bubbled up as an error-level log entry in the host process's own log stream. `AccessDenied` is now handled the same as `ReadFailed`: silent fallback to the default log level and disabled state.

Closes #361 