### PR TITLE
ci: Put major Dockerfile updates behind approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,8 +17,14 @@
     {
       "groupName": "Dockerfile",
       "matchManagers": ["dockerfile"],
-      "matchUpdateTypes": ["minor", "major", "patch", "digest"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
       "schedule": ["before 8am on Monday"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "separateMultipleMajor": true
     },
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Adjusted update types included in Dockerfile group and added new configuration for major docker updates so that major require approval before creation.

This change eliminates the need for keeping a draft pr open & enables digest, patch & minor updates of docker dependencies.