### PR TITLE
chore: Update renovate.json to modify Dockerfile settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,8 +23,7 @@
     {
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["major"],
-      "dependencyDashboardApproval": true,
-      "separateMultipleMajor": true
+      "dependencyDashboardApproval": true
     },
     {
       "groupName": "GitHub Actions",


### PR DESCRIPTION
Closes: #382

Removed 'separateMultipleMajor' from Dockerfile manager settings as it is not supported.