### PR TITLE
chore(build): derive release bump from chloggen entries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,5 +152,9 @@ jobs:
         with:
           body_path: release-notes.md
           fail_on_unmatched_files: true
+          # RC tags (e.g. v0.10.0-rc.1) land as a draft release so maintainers
+          # can review the notes and artifacts before publishing; stable tags
+          # publish immediately.
+          draft: ${{ contains(github.ref_name, '-rc.') }}
           files: |
             artifacts/**/*

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,11 +2,19 @@ name: Automation - Prepare Release
 
 on:
   workflow_dispatch:
-    # Determine the version number that will be assigned to the release.
     inputs:
-      version:
+      override:
+        description: |
+          Override the auto-derived bump. Leave as "auto" to derive from
+          chloggen entries in .chloggen/, or force a specific bump kind.
         required: true
-        description: Release version or release candidate version (like v0.70.0 or v0.70.0-20260109)
+        default: auto
+        type: choice
+        options:
+          - auto
+          - major
+          - minor
+          - patch
 permissions:
   contents: read
 jobs:
@@ -16,19 +24,30 @@ jobs:
       contents: write # required for pushing changes in prepare-release.sh
     runs-on: ubuntu-24.04
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-tags: true
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache: false
+      - name: Determine next release version
+        id: version
+        env:
+          OVERRIDE: ${{ inputs.override }}
+        working-directory: ./tooling/nextversion
+        run: |
+          go run . \
+            -override "$OVERRIDE" \
+            -chloggen-dir ../../.chloggen
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token
         with:
           client-id: ${{ vars.OTELBOT_CLIENT_ID }}
           private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          go-version: "1.26.5"
-          cache: false
       - name: Prepare release for injector
         env:
           GITHUB_TOKEN: ${{ steps.otelbot-token.outputs.token }}
           REPO: open-telemetry/opentelemetry-injector
-          VERSION: ${{ inputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
         run: ./.github/workflows/scripts/prepare-release.sh

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,6 +15,15 @@ on:
           - major
           - minor
           - patch
+      prerelease:
+        description: |
+          When true, release the next release candidate for the computed
+          version instead of the stable release, tagging v<computed>-rc.<N>
+          where N is one greater than the highest existing rc index for the
+          same base version (or 1 if no prior rc exists).
+        required: false
+        default: false
+        type: boolean
 permissions:
   contents: read
 jobs:
@@ -35,10 +44,12 @@ jobs:
         id: version
         env:
           OVERRIDE: ${{ inputs.override }}
+          PRERELEASE: ${{ inputs.prerelease }}
         working-directory: ./tooling/nextversion
         run: |
           go run . \
             -override "$OVERRIDE" \
+            -prerelease="$PRERELEASE" \
             -chloggen-dir ../../.chloggen
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: otelbot-token

--- a/.github/workflows/tooling.yml
+++ b/.github/workflows/tooling.yml
@@ -1,0 +1,33 @@
+name: Tooling
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "tooling/**"
+      - ".github/workflows/tooling.yml"
+  pull_request:
+    paths:
+      - "tooling/**"
+      - ".github/workflows/tooling.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  nextversion:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: "1.26.5"
+          cache: true
+          cache-dependency-path: tooling/nextversion/go.sum
+      - name: go vet
+        working-directory: ./tooling/nextversion
+        run: go vet ./...
+      - name: go test
+        working-directory: ./tooling/nextversion
+        run: go test -race -count=1 ./...

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 An approver or maintainer can run the GitHub action to [prepare the release from the GitHub Actions page of the repository](https://github.com/open-telemetry/opentelemetry-injector/actions/workflows/prepare-release.yml).
 
-The pattern for the version should be vX.Y.Z for a regular release, or vX.Y.Z-<additional-qualfier> for a release candidate.
+The action asks for an `override` input with the choices `auto` (default), `major`, `minor`, or `patch`. When left as `auto`, the release-tooling program at [tooling/nextversion](tooling/nextversion) derives the bump from the `change_type` of the chloggen entries in [.chloggen](.chloggen) (`breaking` -> major, `deprecation`/`new_component`/`enhancement` -> minor, `bug_fix` -> patch; while the current release is on `0.y.z`, a `breaking` change is bumped as minor per the semver 0.x convention). Any of `major`, `minor`, `patch` overrides the auto-derived bump. The action then bumps the appropriate component of the most recent stable `vX.Y.Z` tag, so there is no need to type out the full version.
 
 The action will trigger the creation of a pull request for review by project approvers ([example](https://github.com/open-telemetry/opentelemetry-injector/pull/112)).
 

--- a/tooling/nextversion/go.mod
+++ b/tooling/nextversion/go.mod
@@ -1,0 +1,5 @@
+module github.com/open-telemetry/opentelemetry-injector/tooling/nextversion
+
+go 1.23
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/tooling/nextversion/go.sum
+++ b/tooling/nextversion/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tooling/nextversion/main.go
+++ b/tooling/nextversion/main.go
@@ -25,10 +25,12 @@ func main() {
 func run() error {
 	var (
 		override     string
+		prerelease   bool
 		chloggenDir  string
 		gitTagOutput string
 	)
 	flag.StringVar(&override, "override", "auto", "override the auto-derived bump: auto, major, minor, or patch")
+	flag.BoolVar(&prerelease, "prerelease", false, "when true, produce the next v<computed>-rc.<N> instead of the stable version")
 	flag.StringVar(&chloggenDir, "chloggen-dir", ".chloggen", "directory containing chloggen entry files")
 	flag.StringVar(&gitTagOutput, "git-tag-output", "", "(testing) read the tag list from this file instead of running git")
 	flag.Parse()
@@ -51,6 +53,10 @@ func run() error {
 	}
 
 	next := latest.Apply(kind)
+	if prerelease {
+		idx := NextRCIndex(tags, next)
+		next = next.WithPreRelease(fmt.Sprintf("rc.%d", idx))
+	}
 	fmt.Fprintf(os.Stderr, "Next release version (%s bump): %s\n", kind, next)
 	fmt.Println(next)
 

--- a/tooling/nextversion/main.go
+++ b/tooling/nextversion/main.go
@@ -1,0 +1,155 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "error:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	var (
+		override     string
+		chloggenDir  string
+		gitTagOutput string
+	)
+	flag.StringVar(&override, "override", "auto", "override the auto-derived bump: auto, major, minor, or patch")
+	flag.StringVar(&chloggenDir, "chloggen-dir", ".chloggen", "directory containing chloggen entry files")
+	flag.StringVar(&gitTagOutput, "git-tag-output", "", "(testing) read the tag list from this file instead of running git")
+	flag.Parse()
+
+	tags, err := loadTags(gitTagOutput)
+	if err != nil {
+		return fmt.Errorf("listing git tags: %w", err)
+	}
+
+	latest, hasLatest := LatestStable(tags)
+	if !hasLatest {
+		fmt.Fprintln(os.Stderr, "No prior stable release tag found; starting from v0.0.0.")
+	} else {
+		fmt.Fprintf(os.Stderr, "Latest stable release tag: %s\n", latest)
+	}
+
+	kind, err := resolveBump(override, chloggenDir)
+	if err != nil {
+		return err
+	}
+
+	next := latest.Apply(kind)
+	fmt.Fprintf(os.Stderr, "Next release version (%s bump): %s\n", kind, next)
+	fmt.Println(next)
+
+	return writeGitHubOutput(next, kind)
+}
+
+func loadTags(fromFile string) ([]string, error) {
+	if fromFile != "" {
+		data, err := os.ReadFile(fromFile)
+		if err != nil {
+			return nil, err
+		}
+		return splitLines(string(data)), nil
+	}
+	cmd := exec.Command("git", "tag")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return splitLines(string(out)), nil
+}
+
+func splitLines(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
+func resolveBump(override, chloggenDir string) (BumpKind, error) {
+	if override != "" && override != "auto" {
+		kind, err := ParseBumpKind(override)
+		if err != nil {
+			return BumpNone, err
+		}
+		fmt.Fprintf(os.Stderr, "Bump overridden to: %s\n", kind)
+		return kind, nil
+	}
+
+	changeTypes, err := readChloggenChangeTypes(chloggenDir)
+	if err != nil {
+		return BumpNone, fmt.Errorf("reading chloggen entries from %s: %w", chloggenDir, err)
+	}
+	kind, err := DeriveBump(changeTypes)
+	if err != nil {
+		if errors.Is(err, ErrNoEntries) {
+			return BumpNone, fmt.Errorf("no chloggen entries in %s -- either add one or pass -override=patch", chloggenDir)
+		}
+		return BumpNone, err
+	}
+	fmt.Fprintf(os.Stderr, "Bump derived from %d chloggen entries: %s\n", len(changeTypes), kind)
+	return kind, nil
+}
+
+// readChloggenChangeTypes loads *.yaml files from dir, skipping the template
+// and config files that live alongside the entries, and returns the
+// change_type of each entry in file-order.
+func readChloggenChangeTypes(dir string) ([]ChangeType, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	var types []ChangeType
+	for _, p := range matches {
+		base := filepath.Base(p)
+		if base == "TEMPLATE.yaml" || base == "config.yaml" {
+			continue
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil, err
+		}
+		var entry struct {
+			ChangeType string `yaml:"change_type"`
+		}
+		if err := yaml.Unmarshal(data, &entry); err != nil {
+			return nil, fmt.Errorf("%s: %w", p, err)
+		}
+		if entry.ChangeType == "" {
+			return nil, fmt.Errorf("%s: empty change_type", p)
+		}
+		types = append(types, ChangeType(entry.ChangeType))
+	}
+	return types, nil
+}
+
+func writeGitHubOutput(v Semver, kind BumpKind) error {
+	path := os.Getenv("GITHUB_OUTPUT")
+	if path == "" {
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		return fmt.Errorf("open GITHUB_OUTPUT: %w", err)
+	}
+	defer f.Close()
+	if _, err := fmt.Fprintf(f, "version=%s\nbump=%s\n", v, kind); err != nil {
+		return fmt.Errorf("write GITHUB_OUTPUT: %w", err)
+	}
+	return nil
+}

--- a/tooling/nextversion/main_test.go
+++ b/tooling/nextversion/main_test.go
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestLoadTagsFromFile(t *testing.T) {
+	dir := t.TempDir()
+	tags := "v0.9.2\nv0.9.1\nv1.0.0-rc1\nrandom-tag\n"
+	path := filepath.Join(dir, "tags")
+	if err := os.WriteFile(path, []byte(tags), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadTags(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"v0.9.2", "v0.9.1", "v1.0.0-rc1", "random-tag"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("loadTags = %v; want %v", got, want)
+	}
+}
+
+func TestLoadTagsFromFileEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tags")
+	if err := os.WriteFile(path, []byte("\n\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadTags(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("loadTags on empty file = %v; want nil", got)
+	}
+}
+
+func TestReadChloggenChangeTypes(t *testing.T) {
+	dir := t.TempDir()
+
+	// Files that should be skipped by name.
+	writeFile(t, filepath.Join(dir, "TEMPLATE.yaml"), "change_type: enhancement\n")
+	writeFile(t, filepath.Join(dir, "config.yaml"), "entries_dir: .\n")
+	// A markdown file that must not be picked up.
+	writeFile(t, filepath.Join(dir, "notes.md"), "not yaml\n")
+
+	// Actual entries.
+	writeFile(t, filepath.Join(dir, "a-fix.yaml"), "change_type: bug_fix\ncomponent: injector\n")
+	writeFile(t, filepath.Join(dir, "b-feature.yaml"), "change_type: enhancement\ncomponent: injector\n")
+
+	got, err := readChloggenChangeTypes(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []ChangeType{ChangeBugFix, ChangeEnhancement}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("readChloggenChangeTypes = %v; want %v", got, want)
+	}
+}
+
+func TestReadChloggenChangeTypesMissingChangeType(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), "component: injector\n")
+
+	_, err := readChloggenChangeTypes(dir)
+	if err == nil {
+		t.Fatal("expected error for missing change_type; got nil")
+	}
+	if !strings.Contains(err.Error(), "empty change_type") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestReadChloggenChangeTypesMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), ": : : not-yaml\n")
+
+	_, err := readChloggenChangeTypes(dir)
+	if err == nil {
+		t.Fatal("expected error for malformed yaml; got nil")
+	}
+}
+
+func TestReadChloggenChangeTypesEmptyDirIsNoEntries(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := readChloggenChangeTypes(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no entries; got %v", got)
+	}
+
+	// And DeriveBump on an empty slice yields ErrNoEntries -- covered in
+	// nextversion_test.go, but reconfirm the composed behavior here.
+	if _, err := DeriveBump(got); err == nil {
+		t.Fatal("DeriveBump on empty entries should error")
+	}
+}
+
+func TestResolveBumpOverride(t *testing.T) {
+	// override wins even if chloggen dir does not exist.
+	got, err := resolveBump("patch", filepath.Join(t.TempDir(), "does-not-exist"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != BumpPatch {
+		t.Errorf("got %v; want BumpPatch", got)
+	}
+}
+
+func TestResolveBumpAutoDerives(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.yaml"), "change_type: breaking\ncomponent: x\n")
+
+	got, err := resolveBump("auto", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != BumpMajor {
+		t.Errorf("got %v; want BumpMajor", got)
+	}
+}
+
+func TestResolveBumpAutoNoEntriesWrapsError(t *testing.T) {
+	dir := t.TempDir()
+	_, err := resolveBump("auto", dir)
+	if err == nil {
+		t.Fatal("expected error; got nil")
+	}
+	if !strings.Contains(err.Error(), "no chloggen entries") {
+		t.Errorf("expected 'no chloggen entries' hint, got: %v", err)
+	}
+}
+
+func TestWriteGitHubOutput(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out")
+	t.Setenv("GITHUB_OUTPUT", path)
+
+	if err := writeGitHubOutput(Semver{0, 10, 0}, BumpMinor); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "version=v0.10.0\nbump=minor\n"
+	if string(data) != want {
+		t.Errorf("got %q; want %q", string(data), want)
+	}
+}
+
+func TestWriteGitHubOutputAppends(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out")
+	if err := os.WriteFile(path, []byte("previous=value\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GITHUB_OUTPUT", path)
+
+	if err := writeGitHubOutput(Semver{1, 0, 0}, BumpMajor); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "previous=value\nversion=v1.0.0\nbump=major\n"
+	if string(data) != want {
+		t.Errorf("got %q; want %q", string(data), want)
+	}
+}
+
+func TestWriteGitHubOutputEmptyEnvIsNoop(t *testing.T) {
+	t.Setenv("GITHUB_OUTPUT", "")
+	if err := writeGitHubOutput(Semver{0, 1, 0}, BumpMinor); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(contents), 0600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tooling/nextversion/main_test.go
+++ b/tooling/nextversion/main_test.go
@@ -147,7 +147,7 @@ func TestWriteGitHubOutput(t *testing.T) {
 	path := filepath.Join(dir, "out")
 	t.Setenv("GITHUB_OUTPUT", path)
 
-	if err := writeGitHubOutput(Semver{0, 10, 0}, BumpMinor); err != nil {
+	if err := writeGitHubOutput(Semver{Major: 0, Minor: 10, Patch: 0}, BumpMinor); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -168,7 +168,7 @@ func TestWriteGitHubOutputAppends(t *testing.T) {
 	}
 	t.Setenv("GITHUB_OUTPUT", path)
 
-	if err := writeGitHubOutput(Semver{1, 0, 0}, BumpMajor); err != nil {
+	if err := writeGitHubOutput(Semver{Major: 1, Minor: 0, Patch: 0}, BumpMajor); err != nil {
 		t.Fatal(err)
 	}
 	data, err := os.ReadFile(path)
@@ -183,7 +183,7 @@ func TestWriteGitHubOutputAppends(t *testing.T) {
 
 func TestWriteGitHubOutputEmptyEnvIsNoop(t *testing.T) {
 	t.Setenv("GITHUB_OUTPUT", "")
-	if err := writeGitHubOutput(Semver{0, 1, 0}, BumpMinor); err != nil {
+	if err := writeGitHubOutput(Semver{Major: 0, Minor: 1, Patch: 0}, BumpMinor); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tooling/nextversion/nextversion.go
+++ b/tooling/nextversion/nextversion.go
@@ -1,0 +1,184 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package main implements a small tool that computes the next release version
+// by combining the highest existing stable git tag with a bump kind. The bump
+// kind is derived from the change_type field of chloggen entries in .chloggen/
+// unless overridden on the command line.
+//
+// This file contains only pure functions and types; all I/O (git, filesystem,
+// GitHub Actions outputs) lives in main.go.
+package main
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Semver is a bare-bones vMAJOR.MINOR.PATCH version. Pre-release and build
+// metadata are intentionally not modeled: the release process only ever bumps
+// stable tags.
+type Semver struct {
+	Major int
+	Minor int
+	Patch int
+}
+
+var stableSemverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
+
+// ParseStableSemver parses "vX.Y.Z" (no pre-release suffix). Anything else
+// returns ok=false so callers can filter tag lists in one pass.
+func ParseStableSemver(s string) (Semver, bool) {
+	m := stableSemverRe.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return Semver{}, false
+	}
+	maj, _ := strconv.Atoi(m[1])
+	min, _ := strconv.Atoi(m[2])
+	pat, _ := strconv.Atoi(m[3])
+	return Semver{maj, min, pat}, true
+}
+
+func (v Semver) String() string {
+	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
+
+// Less reports whether v is strictly older than o.
+func (v Semver) Less(o Semver) bool {
+	if v.Major != o.Major {
+		return v.Major < o.Major
+	}
+	if v.Minor != o.Minor {
+		return v.Minor < o.Minor
+	}
+	return v.Patch < o.Patch
+}
+
+// LatestStable picks the highest vX.Y.Z tag from the given list, skipping
+// anything that isn't a stable semver tag. Returns ok=false when the input
+// contains no stable tags.
+func LatestStable(tags []string) (Semver, bool) {
+	var best Semver
+	found := false
+	for _, t := range tags {
+		v, ok := ParseStableSemver(t)
+		if !ok {
+			continue
+		}
+		if !found || best.Less(v) {
+			best = v
+			found = true
+		}
+	}
+	return best, found
+}
+
+// BumpKind enumerates the semver components in ascending priority order, so
+// numeric comparison picks the strongest bump when combining classifications.
+type BumpKind int
+
+const (
+	BumpNone BumpKind = iota
+	BumpPatch
+	BumpMinor
+	BumpMajor
+)
+
+func (b BumpKind) String() string {
+	switch b {
+	case BumpPatch:
+		return "patch"
+	case BumpMinor:
+		return "minor"
+	case BumpMajor:
+		return "major"
+	default:
+		return "none"
+	}
+}
+
+// ParseBumpKind parses the CLI-facing spelling of a bump kind.
+func ParseBumpKind(s string) (BumpKind, error) {
+	switch s {
+	case "patch":
+		return BumpPatch, nil
+	case "minor":
+		return BumpMinor, nil
+	case "major":
+		return BumpMajor, nil
+	}
+	return BumpNone, fmt.Errorf("invalid bump kind %q (want major, minor, or patch)", s)
+}
+
+// Apply returns the version resulting from bumping v by kind.
+//
+// While v is pre-1.0.0, a "major" bump is downgraded to a minor bump per the
+// common 0.y.z convention: breaking changes may happen in a minor release
+// until the project commits to a stable v1.
+func (v Semver) Apply(kind BumpKind) Semver {
+	switch kind {
+	case BumpMajor:
+		if v.Major == 0 {
+			return Semver{Major: 0, Minor: v.Minor + 1, Patch: 0}
+		}
+		return Semver{Major: v.Major + 1, Minor: 0, Patch: 0}
+	case BumpMinor:
+		return Semver{Major: v.Major, Minor: v.Minor + 1, Patch: 0}
+	case BumpPatch:
+		return Semver{Major: v.Major, Minor: v.Minor, Patch: v.Patch + 1}
+	}
+	return v
+}
+
+// ChangeType is the string chloggen writes into an entry file's change_type
+// field. The known values are enumerated below.
+type ChangeType string
+
+const (
+	ChangeBreaking     ChangeType = "breaking"
+	ChangeDeprecation  ChangeType = "deprecation"
+	ChangeNewComponent ChangeType = "new_component"
+	ChangeEnhancement  ChangeType = "enhancement"
+	ChangeBugFix       ChangeType = "bug_fix"
+)
+
+// ClassifyChangeType maps a chloggen change_type to the bump kind it
+// warrants. Returns BumpNone for unknown values so callers can flag them.
+func ClassifyChangeType(ct ChangeType) BumpKind {
+	switch ct {
+	case ChangeBreaking:
+		return BumpMajor
+	case ChangeDeprecation, ChangeNewComponent, ChangeEnhancement:
+		return BumpMinor
+	case ChangeBugFix:
+		return BumpPatch
+	}
+	return BumpNone
+}
+
+// ErrNoEntries is returned when auto-derivation is requested but no chloggen
+// entries were provided.
+var ErrNoEntries = errors.New("no chloggen entries found")
+
+// DeriveBump picks the strongest bump warranted by the given change types.
+// An unknown change type is treated as a fatal error rather than silently
+// ignored -- releases should never be classified from partial information.
+func DeriveBump(changeTypes []ChangeType) (BumpKind, error) {
+	if len(changeTypes) == 0 {
+		return BumpNone, ErrNoEntries
+	}
+	best := BumpNone
+	for _, ct := range changeTypes {
+		k := ClassifyChangeType(ct)
+		if k == BumpNone {
+			return BumpNone, fmt.Errorf("unknown change_type %q", string(ct))
+		}
+		if k > best {
+			best = k
+		}
+	}
+	return best, nil
+}

--- a/tooling/nextversion/nextversion.go
+++ b/tooling/nextversion/nextversion.go
@@ -18,13 +18,17 @@ import (
 	"strings"
 )
 
-// Semver is a bare-bones vMAJOR.MINOR.PATCH version. Pre-release and build
-// metadata are intentionally not modeled: the release process only ever bumps
-// stable tags.
+// Semver is a bare-bones vMAJOR.MINOR.PATCH version, optionally carrying a
+// SemVer 2.0.0 pre-release suffix (e.g. "rc.1"). Build metadata is not
+// modeled. The pre-release field is only ever populated on the *output*
+// version; parsed tags always have an empty PreRelease -- LatestStable
+// deliberately skips pre-release tags so the next release is computed from
+// the last stable base.
 type Semver struct {
-	Major int
-	Minor int
-	Patch int
+	Major      int
+	Minor      int
+	Patch      int
+	PreRelease string
 }
 
 var stableSemverRe = regexp.MustCompile(`^v(\d+)\.(\d+)\.(\d+)$`)
@@ -39,11 +43,57 @@ func ParseStableSemver(s string) (Semver, bool) {
 	maj, _ := strconv.Atoi(m[1])
 	min, _ := strconv.Atoi(m[2])
 	pat, _ := strconv.Atoi(m[3])
-	return Semver{maj, min, pat}, true
+	return Semver{Major: maj, Minor: min, Patch: pat}, true
 }
 
 func (v Semver) String() string {
-	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	base := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	if v.PreRelease == "" {
+		return base
+	}
+	return base + "-" + v.PreRelease
+}
+
+// WithPreRelease returns a copy of v with the given SemVer 2.0.0 pre-release
+// identifier attached. An empty argument clears any existing suffix.
+func (v Semver) WithPreRelease(pre string) Semver {
+	v.PreRelease = pre
+	return v
+}
+
+// rcTagRe extracts the rc index from a "vX.Y.Z-rc.N" tag matching the given
+// base version. Built dynamically by NextRCIndex so the base X.Y.Z is
+// literal, and only rc.N is captured.
+func rcTagRe(base Semver) *regexp.Regexp {
+	pattern := fmt.Sprintf(`^v%d\.%d\.%d-rc\.(\d+)$`, base.Major, base.Minor, base.Patch)
+	return regexp.MustCompile(pattern)
+}
+
+// NextRCIndex returns the next rc index for base by scanning tags for
+// existing "v<base>-rc.N" entries and taking max(N)+1. Returns 1 when no
+// prior rc exists. Ignores rc tags whose numeric part has a leading zero
+// (e.g. "-rc.01"), since we never emit those and treating them as valid
+// would produce a duplicate tag on the next run.
+func NextRCIndex(tags []string, base Semver) int {
+	re := rcTagRe(base)
+	best := 0
+	for _, t := range tags {
+		m := re.FindStringSubmatch(strings.TrimSpace(t))
+		if m == nil {
+			continue
+		}
+		if len(m[1]) > 1 && m[1][0] == '0' {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		if n > best {
+			best = n
+		}
+	}
+	return best + 1
 }
 
 // Less reports whether v is strictly older than o.

--- a/tooling/nextversion/nextversion_test.go
+++ b/tooling/nextversion/nextversion_test.go
@@ -14,10 +14,10 @@ func TestParseStableSemver(t *testing.T) {
 		want   Semver
 		wantOK bool
 	}{
-		{"v0.9.2", Semver{0, 9, 2}, true},
-		{"v1.0.0", Semver{1, 0, 0}, true},
-		{"v10.20.30", Semver{10, 20, 30}, true},
-		{"  v1.2.3  ", Semver{1, 2, 3}, true},
+		{"v0.9.2", Semver{Major: 0, Minor: 9, Patch: 2}, true},
+		{"v1.0.0", Semver{Major: 1, Minor: 0, Patch: 0}, true},
+		{"v10.20.30", Semver{Major: 10, Minor: 20, Patch: 30}, true},
+		{"  v1.2.3  ", Semver{Major: 1, Minor: 2, Patch: 3}, true},
 		{"v0.9.2-rc1", Semver{}, false},
 		{"v0.9.2-20260101", Semver{}, false},
 		{"0.9.2", Semver{}, false},
@@ -37,11 +37,11 @@ func TestSemverLess(t *testing.T) {
 		a, b Semver
 		want bool
 	}{
-		{Semver{0, 9, 2}, Semver{0, 10, 0}, true},
-		{Semver{0, 10, 0}, Semver{0, 9, 2}, false},
-		{Semver{1, 0, 0}, Semver{0, 99, 99}, false},
-		{Semver{0, 9, 2}, Semver{0, 9, 2}, false},
-		{Semver{0, 9, 2}, Semver{0, 9, 3}, true},
+		{Semver{Major: 0, Minor: 9, Patch: 2}, Semver{Major: 0, Minor: 10, Patch: 0}, true},
+		{Semver{Major: 0, Minor: 10, Patch: 0}, Semver{Major: 0, Minor: 9, Patch: 2}, false},
+		{Semver{Major: 1, Minor: 0, Patch: 0}, Semver{Major: 0, Minor: 99, Patch: 99}, false},
+		{Semver{Major: 0, Minor: 9, Patch: 2}, Semver{Major: 0, Minor: 9, Patch: 2}, false},
+		{Semver{Major: 0, Minor: 9, Patch: 2}, Semver{Major: 0, Minor: 9, Patch: 3}, true},
 	}
 	for _, c := range cases {
 		if got := c.a.Less(c.b); got != c.want {
@@ -60,25 +60,25 @@ func TestLatestStable(t *testing.T) {
 		{
 			name:   "picks highest stable",
 			tags:   []string{"v0.9.0", "v0.9.2", "v0.9.1", "v0.8.0"},
-			want:   Semver{0, 9, 2},
+			want:   Semver{Major: 0, Minor: 9, Patch: 2},
 			wantOK: true,
 		},
 		{
 			name:   "ignores pre-release tags",
 			tags:   []string{"v0.9.2", "v1.0.0-rc1", "v0.9.3-20260101", "v2.0.0-beta"},
-			want:   Semver{0, 9, 2},
+			want:   Semver{Major: 0, Minor: 9, Patch: 2},
 			wantOK: true,
 		},
 		{
 			name:   "ignores non-semver tags",
 			tags:   []string{"random-tag", "v0.2.0", "not-a-tag", "v0.3.0"},
-			want:   Semver{0, 3, 0},
+			want:   Semver{Major: 0, Minor: 3, Patch: 0},
 			wantOK: true,
 		},
 		{
 			name:   "picks highest not most-recent",
 			tags:   []string{"v2.0.0", "v0.9.2", "v1.9.9"},
-			want:   Semver{2, 0, 0},
+			want:   Semver{Major: 2, Minor: 0, Patch: 0},
 			wantOK: true,
 		},
 		{
@@ -112,14 +112,14 @@ func TestApply(t *testing.T) {
 		kind BumpKind
 		want Semver
 	}{
-		{"patch bump", Semver{0, 9, 2}, BumpPatch, Semver{0, 9, 3}},
-		{"minor bump resets patch", Semver{0, 9, 2}, BumpMinor, Semver{0, 10, 0}},
-		{"minor bump double-digit", Semver{1, 9, 9}, BumpMinor, Semver{1, 10, 0}},
-		{"major on 0.x demotes to minor", Semver{0, 9, 2}, BumpMajor, Semver{0, 10, 0}},
-		{"major on 1.x resets minor/patch", Semver{1, 4, 5}, BumpMajor, Semver{2, 0, 0}},
-		{"major on 1.99.99 wraps to 2.0.0", Semver{1, 99, 99}, BumpMajor, Semver{2, 0, 0}},
-		{"patch double-digit", Semver{1, 9, 9}, BumpPatch, Semver{1, 9, 10}},
-		{"none returns identity", Semver{0, 9, 2}, BumpNone, Semver{0, 9, 2}},
+		{"patch bump", Semver{Major: 0, Minor: 9, Patch: 2}, BumpPatch, Semver{Major: 0, Minor: 9, Patch: 3}},
+		{"minor bump resets patch", Semver{Major: 0, Minor: 9, Patch: 2}, BumpMinor, Semver{Major: 0, Minor: 10, Patch: 0}},
+		{"minor bump double-digit", Semver{Major: 1, Minor: 9, Patch: 9}, BumpMinor, Semver{Major: 1, Minor: 10, Patch: 0}},
+		{"major on 0.x demotes to minor", Semver{Major: 0, Minor: 9, Patch: 2}, BumpMajor, Semver{Major: 0, Minor: 10, Patch: 0}},
+		{"major on 1.x resets minor/patch", Semver{Major: 1, Minor: 4, Patch: 5}, BumpMajor, Semver{Major: 2, Minor: 0, Patch: 0}},
+		{"major on 1.99.99 wraps to 2.0.0", Semver{Major: 1, Minor: 99, Patch: 99}, BumpMajor, Semver{Major: 2, Minor: 0, Patch: 0}},
+		{"patch double-digit", Semver{Major: 1, Minor: 9, Patch: 9}, BumpPatch, Semver{Major: 1, Minor: 9, Patch: 10}},
+		{"none returns identity", Semver{Major: 0, Minor: 9, Patch: 2}, BumpNone, Semver{Major: 0, Minor: 9, Patch: 2}},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -242,6 +242,67 @@ func TestDeriveBump(t *testing.T) {
 				if !errors.Is(err, c.wantErr) {
 					t.Errorf("want error %v, got %v", c.wantErr, err)
 				}
+			}
+		})
+	}
+}
+
+func TestWithPreReleaseAppendsSuffix(t *testing.T) {
+	got := Semver{Major: 0, Minor: 10, Patch: 0}.WithPreRelease("rc.1").String()
+	if got != "v0.10.0-rc.1" {
+		t.Errorf("got %q; want v0.10.0-rc.1", got)
+	}
+}
+
+func TestWithPreReleaseEmptyIsStable(t *testing.T) {
+	got := Semver{Major: 0, Minor: 10, Patch: 0}.WithPreRelease("").String()
+	if got != "v0.10.0" {
+		t.Errorf("got %q; want v0.10.0", got)
+	}
+}
+
+func TestNextRCIndex(t *testing.T) {
+	base := Semver{Major: 0, Minor: 10, Patch: 0}
+	cases := []struct {
+		name string
+		tags []string
+		want int
+	}{
+		{
+			name: "no rc tags -> 1",
+			tags: []string{"v0.9.0", "v0.9.1", "v0.9.2"},
+			want: 1,
+		},
+		{
+			name: "picks max+1",
+			tags: []string{"v0.10.0-rc.1", "v0.10.0-rc.3", "v0.10.0-rc.2"},
+			want: 4,
+		},
+		{
+			name: "ignores rc tags for other versions",
+			tags: []string{"v0.9.0-rc.7", "v0.11.0-rc.5", "v0.10.0-rc.1"},
+			want: 2,
+		},
+		{
+			name: "ignores rc tags with leading zeros",
+			tags: []string{"v0.10.0-rc.01", "v0.10.0-rc.02"},
+			want: 1,
+		},
+		{
+			name: "ignores non-rc pre-release tags",
+			tags: []string{"v0.10.0-beta.1", "v0.10.0-alpha", "v0.10.0-rc"},
+			want: 1,
+		},
+		{
+			name: "handles surrounding whitespace",
+			tags: []string{"  v0.10.0-rc.2  ", "v0.10.0-rc.5\n"},
+			want: 6,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := NextRCIndex(c.tags, base); got != c.want {
+				t.Errorf("NextRCIndex = %d; want %d", got, c.want)
 			}
 		})
 	}

--- a/tooling/nextversion/nextversion_test.go
+++ b/tooling/nextversion/nextversion_test.go
@@ -1,0 +1,263 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseStableSemver(t *testing.T) {
+	cases := []struct {
+		in     string
+		want   Semver
+		wantOK bool
+	}{
+		{"v0.9.2", Semver{0, 9, 2}, true},
+		{"v1.0.0", Semver{1, 0, 0}, true},
+		{"v10.20.30", Semver{10, 20, 30}, true},
+		{"  v1.2.3  ", Semver{1, 2, 3}, true},
+		{"v0.9.2-rc1", Semver{}, false},
+		{"v0.9.2-20260101", Semver{}, false},
+		{"0.9.2", Semver{}, false},
+		{"random-tag", Semver{}, false},
+		{"", Semver{}, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseStableSemver(c.in)
+		if ok != c.wantOK || got != c.want {
+			t.Errorf("ParseStableSemver(%q) = (%v, %v); want (%v, %v)", c.in, got, ok, c.want, c.wantOK)
+		}
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	cases := []struct {
+		a, b Semver
+		want bool
+	}{
+		{Semver{0, 9, 2}, Semver{0, 10, 0}, true},
+		{Semver{0, 10, 0}, Semver{0, 9, 2}, false},
+		{Semver{1, 0, 0}, Semver{0, 99, 99}, false},
+		{Semver{0, 9, 2}, Semver{0, 9, 2}, false},
+		{Semver{0, 9, 2}, Semver{0, 9, 3}, true},
+	}
+	for _, c := range cases {
+		if got := c.a.Less(c.b); got != c.want {
+			t.Errorf("(%s).Less(%s) = %v; want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestLatestStable(t *testing.T) {
+	cases := []struct {
+		name   string
+		tags   []string
+		want   Semver
+		wantOK bool
+	}{
+		{
+			name:   "picks highest stable",
+			tags:   []string{"v0.9.0", "v0.9.2", "v0.9.1", "v0.8.0"},
+			want:   Semver{0, 9, 2},
+			wantOK: true,
+		},
+		{
+			name:   "ignores pre-release tags",
+			tags:   []string{"v0.9.2", "v1.0.0-rc1", "v0.9.3-20260101", "v2.0.0-beta"},
+			want:   Semver{0, 9, 2},
+			wantOK: true,
+		},
+		{
+			name:   "ignores non-semver tags",
+			tags:   []string{"random-tag", "v0.2.0", "not-a-tag", "v0.3.0"},
+			want:   Semver{0, 3, 0},
+			wantOK: true,
+		},
+		{
+			name:   "picks highest not most-recent",
+			tags:   []string{"v2.0.0", "v0.9.2", "v1.9.9"},
+			want:   Semver{2, 0, 0},
+			wantOK: true,
+		},
+		{
+			name:   "empty input",
+			tags:   nil,
+			wantOK: false,
+		},
+		{
+			name:   "only pre-release tags",
+			tags:   []string{"v1.0.0-rc1", "v0.5.0-beta"},
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := LatestStable(c.tags)
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v; want %v", ok, c.wantOK)
+			}
+			if ok && got != c.want {
+				t.Errorf("got %s; want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestApply(t *testing.T) {
+	cases := []struct {
+		name string
+		base Semver
+		kind BumpKind
+		want Semver
+	}{
+		{"patch bump", Semver{0, 9, 2}, BumpPatch, Semver{0, 9, 3}},
+		{"minor bump resets patch", Semver{0, 9, 2}, BumpMinor, Semver{0, 10, 0}},
+		{"minor bump double-digit", Semver{1, 9, 9}, BumpMinor, Semver{1, 10, 0}},
+		{"major on 0.x demotes to minor", Semver{0, 9, 2}, BumpMajor, Semver{0, 10, 0}},
+		{"major on 1.x resets minor/patch", Semver{1, 4, 5}, BumpMajor, Semver{2, 0, 0}},
+		{"major on 1.99.99 wraps to 2.0.0", Semver{1, 99, 99}, BumpMajor, Semver{2, 0, 0}},
+		{"patch double-digit", Semver{1, 9, 9}, BumpPatch, Semver{1, 9, 10}},
+		{"none returns identity", Semver{0, 9, 2}, BumpNone, Semver{0, 9, 2}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.base.Apply(c.kind); got != c.want {
+				t.Errorf("(%s).Apply(%s) = %s; want %s", c.base, c.kind, got, c.want)
+			}
+		})
+	}
+}
+
+func TestParseBumpKind(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    BumpKind
+		wantErr bool
+	}{
+		{"major", BumpMajor, false},
+		{"minor", BumpMinor, false},
+		{"patch", BumpPatch, false},
+		{"MAJOR", BumpNone, true},
+		{"", BumpNone, true},
+		{"bogus", BumpNone, true},
+	}
+	for _, c := range cases {
+		got, err := ParseBumpKind(c.in)
+		if (err != nil) != c.wantErr {
+			t.Errorf("ParseBumpKind(%q) err = %v; wantErr = %v", c.in, err, c.wantErr)
+		}
+		if got != c.want {
+			t.Errorf("ParseBumpKind(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestClassifyChangeType(t *testing.T) {
+	cases := []struct {
+		in   ChangeType
+		want BumpKind
+	}{
+		{ChangeBreaking, BumpMajor},
+		{ChangeDeprecation, BumpMinor},
+		{ChangeNewComponent, BumpMinor},
+		{ChangeEnhancement, BumpMinor},
+		{ChangeBugFix, BumpPatch},
+		{ChangeType("unknown"), BumpNone},
+		{ChangeType(""), BumpNone},
+	}
+	for _, c := range cases {
+		if got := ClassifyChangeType(c.in); got != c.want {
+			t.Errorf("ClassifyChangeType(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestDeriveBump(t *testing.T) {
+	cases := []struct {
+		name    string
+		in      []ChangeType
+		want    BumpKind
+		wantErr error
+	}{
+		{
+			name: "single bug_fix -> patch",
+			in:   []ChangeType{ChangeBugFix},
+			want: BumpPatch,
+		},
+		{
+			name: "single enhancement -> minor",
+			in:   []ChangeType{ChangeEnhancement},
+			want: BumpMinor,
+		},
+		{
+			name: "single breaking -> major",
+			in:   []ChangeType{ChangeBreaking},
+			want: BumpMajor,
+		},
+		{
+			name: "picks strongest across many",
+			in:   []ChangeType{ChangeBugFix, ChangeEnhancement, ChangeBugFix},
+			want: BumpMinor,
+		},
+		{
+			name: "breaking dominates enhancement and bug_fix",
+			in:   []ChangeType{ChangeBugFix, ChangeBreaking, ChangeEnhancement},
+			want: BumpMajor,
+		},
+		{
+			name: "deprecation and new_component are minor",
+			in:   []ChangeType{ChangeDeprecation, ChangeNewComponent, ChangeBugFix},
+			want: BumpMinor,
+		},
+		{
+			name:    "empty input errors with ErrNoEntries",
+			in:      nil,
+			wantErr: ErrNoEntries,
+		},
+		{
+			name:    "unknown change_type errors",
+			in:      []ChangeType{ChangeBugFix, ChangeType("wild")},
+			wantErr: errUnknown{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := DeriveBump(c.in)
+			switch want := c.wantErr.(type) {
+			case nil:
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != c.want {
+					t.Errorf("got %v; want %v", got, c.want)
+				}
+			case errUnknown:
+				_ = want
+				if err == nil || !containsSubstring(err.Error(), "unknown change_type") {
+					t.Errorf("want unknown change_type error, got: %v", err)
+				}
+			default:
+				if !errors.Is(err, c.wantErr) {
+					t.Errorf("want error %v, got %v", c.wantErr, err)
+				}
+			}
+		})
+	}
+}
+
+// errUnknown is a marker type used by TestDeriveBump to assert on
+// unknown-change-type error text without pinning the exact string.
+type errUnknown struct{}
+
+func (errUnknown) Error() string { return "" }
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Replace the free-form `version` input on the prepare-release workflow with an `override` choice input (`auto` / `major` / `minor` / `patch`, default `auto`).

Classification: `breaking` → major, `deprecation` / `new_component` / `enhancement` → minor, `bug_fix` → patch. While the release stream is on 0.y.z, a `breaking` change is bumped as minor per the semver 0.x convention.

Fixes #380