### PR TITLE
chore(ci): fix lychee.toml for lychee v0.24.2

### DIFF
--- a/.github/lychee.toml
+++ b/.github/lychee.toml
@@ -1,4 +1,4 @@
-include_fragments = true
+include_fragments = "full"
 
 accept = ["200..=299", "429"]
 


### PR DESCRIPTION
The changelog check in #400 is failing due to the following:

```
 [ERROR] Error while loading config: Cannot load configuration file `.github/lychee.toml`: Failed to load config from .github/lychee.toml

Caused by:
    0: Failed to parse configuration file
    1: TOML parse error at line 1, column 21
         |
       1 | include_fragments = true
         |                     ^^^^
       wanted string or table
       
See: https://github.com/lycheeverse/lychee/blob/lychee-v0.24.2/lychee.example.toml
```

It appears that lychee changed `include_fragments` from a bool to a string. This PR updates it to replace `true` with `"full"`, which I believe is the correct migration.