### PR TITLE
fix(elf): guard against empty GNU hash bucket to prevent integer overflow panic

### DIFF
--- a/injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile
+++ b/injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile
@@ -1,0 +1,62 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for issue #399:
+# "panic: integer overflow in ElfDynLib.lookupAddress on empty GNU hash bucket"
+#
+# debian:bullseye-slim ships glibc 2.31. On glibc < 2.34, /proc/self/maps shows
+# "libc-2.31.so" not "libc.so.6", so the injector's first pass finds nothing and
+# the second pass scans ALL mapped .so files.
+#
+# A crafted library (trigger.so) has a .gnu.hash section where the bloom filter
+# passes (false positive) for "setenv" but the corresponding bucket value is 0
+# (empty bucket). Without the fix, this causes:
+#   chain_index = 0 - symoffset(1) → u32 underflow → panic: integer overflow → SIGABRT
+#
+# premapper.so maps trigger.so at a fixed low address (0x1000000) before the
+# injector's constructor runs, so the second-pass scan hits it before libc.
+# Because premapper.so is listed second in LD_PRELOAD, its constructor runs first
+# (the dynamic linker initialises later entries first when there are no inter-
+# library dependencies), ensuring trigger.so is already mapped when the injector's
+# initEnviron is called.
+ARG base_image_run="debian:bullseye-slim@sha256:0083feb8da4f624e3a0245e7752af2517d4b81d8b8db50c725644672a132a31b"
+FROM ${base_image_run}
+
+ARG injector_binary
+RUN if [ -z "$injector_binary" ]; then \
+      echo "Error: build argument injector_binary is required but not set."; \
+      exit 1; \
+    fi
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gcc libc6-dev python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/opentelemetry/injector/conf.d && chmod -R 777 /etc/opentelemetry
+
+# Generate the crafted trigger.so with the malformed GNU hash section.
+COPY injector-integration-tests/apps/empty-gnu-hash-bucket/gen_trigger_so.py /tmp/gen_trigger_so.py
+RUN ARCH=$(uname -m); \
+    if [ "$ARCH" = "aarch64" ]; then MACHINE=183; \
+    elif [ "$ARCH" = "x86_64" ]; then MACHINE=62; \
+    else echo "Unsupported arch: $ARCH" && exit 1; fi; \
+    python3 /tmp/gen_trigger_so.py --machine "$MACHINE" /trigger.so
+
+# Build the premapper shared library.
+# It maps /trigger.so at 0x1000000 in its constructor, before the injector runs.
+COPY injector-integration-tests/apps/empty-gnu-hash-bucket/premapper.c /tmp/premapper.c
+RUN gcc -shared -fPIC -o /premapper.so /tmp/premapper.c
+
+WORKDIR /usr/src/otel/injector
+
+# Build the test binary (plain C, no -ldl, so the injector's second pass is triggered).
+COPY injector-integration-tests/apps/empty-gnu-hash-bucket/printenv.c .
+RUN mkdir -p app && gcc -o app/printenv printenv.c && rm printenv.c
+
+COPY injector-integration-tests/scripts/*.sh scripts/
+COPY injector-integration-tests/tests/*.tests tests/
+COPY injector-integration-tests/common/ common/
+
+COPY dist/${injector_binary} /injector/libotelinject.so
+
+CMD ["scripts/run-tests-within-container.sh"]

--- a/injector-integration-tests/apps/empty-gnu-hash-bucket/gen_trigger_so.py
+++ b/injector-integration-tests/apps/empty-gnu-hash-bucket/gen_trigger_so.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+Generate a minimal ELF shared library that triggers the integer overflow bug
+in ElfDynLib.lookupAddress (issue #399).
+
+The .gnu.hash section is crafted so that:
+  - The bloom filter passes (false positive) for "setenv" (hash=0x1b85483a)
+  - The corresponding bucket value is 0 (empty)
+  - chain_index = bucket_value(0) - symoffset(1)
+               = 0 - 1 as u32 → wraps to 0xffffffff → panic in ReleaseSafe
+
+Usage:
+  python3 gen_trigger_so.py [--machine <183|62>] <output.so>
+  183 = EM_AARCH64 (default), 62 = EM_X86_64
+"""
+
+import struct
+import sys
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--machine", type=int, default=183,
+                    help="ELF e_machine: 183=EM_AARCH64, 62=EM_X86_64")
+parser.add_argument("output", help="Output .so path")
+args = parser.parse_args()
+
+MACHINE = args.machine
+OUTPATH = args.output
+
+# --- GNU hash parameters ---
+NBUCKETS    = 1
+SYMOFFSET   = 1   # underflow: bucket_val(0) - symoffset(1) wraps as u32
+BLOOM_SIZE  = 1
+BLOOM_SHIFT = 6
+
+SETENV_HASH = 0x1b85483a  # gnu_hash("setenv")
+bit0 = SETENV_HASH & 63
+bit1 = (SETENV_HASH >> BLOOM_SHIFT) & 63
+bloom_val = (1 << bit0) | (1 << bit1)
+
+# --- Section data ---
+dynstr = b"\x00"  # minimal string table
+
+# STN_UNDEF symbol entry (24 bytes): st_name, st_info, st_other, st_shndx, st_value, st_size
+dynsym = struct.pack("<IBBHQQ", 0, 0, 0, 0, 0, 0)
+
+gnu_hash_data = (
+    struct.pack("<IIII", NBUCKETS, SYMOFFSET, BLOOM_SIZE, BLOOM_SHIFT)  # header
+    + struct.pack("<Q", bloom_val)   # bloom[0]: passes for "setenv"
+    + struct.pack("<I", 0)           # bucket[0] = 0  ← empty bucket → underflow!
+)
+
+# --- Layout ---
+ELF_HDR_SZ = 64
+PHDR_SZ    = 56
+PHDR_CNT   = 2
+
+def align(x, n=8):
+    return (x + n - 1) & ~(n - 1)
+
+phdr_off    = ELF_HDR_SZ
+data_start  = phdr_off + PHDR_CNT * PHDR_SZ  # 176
+
+dynstr_off  = data_start
+dynsym_off  = align(dynstr_off + len(dynstr))
+gnuh_off    = align(dynsym_off + len(dynsym))
+
+DT_NULL     = 0
+DT_STRTAB   = 5
+DT_STRSZ    = 10
+DT_SYMTAB   = 6
+DT_SYMENT   = 11
+DT_GNU_HASH = 0x6ffffef5
+
+dyn_off = align(gnuh_off + len(gnu_hash_data))
+dyn_entries = [
+    (DT_STRTAB,    dynstr_off),
+    (DT_STRSZ,     len(dynstr)),
+    (DT_SYMTAB,    dynsym_off),
+    (DT_SYMENT,    24),
+    (DT_GNU_HASH,  gnuh_off),
+    (DT_NULL,      0),
+]
+dyn_data = b"".join(struct.pack("<QQ", t, v) for t, v in dyn_entries)
+total = align(dyn_off + len(dyn_data))
+
+# --- Program headers ---
+# PT_LOAD: entire file, R+W so the dynamic linker can read it
+phdr_load = struct.pack("<IIQQQQQQ",
+    1,      # PT_LOAD
+    6,      # PF_R | PF_W
+    0,      # offset
+    0,      # vaddr
+    0,      # paddr
+    total,  # filesz
+    total,  # memsz
+    0x1000) # align
+
+# PT_DYNAMIC
+phdr_dyn = struct.pack("<IIQQQQQQ",
+    2,             # PT_DYNAMIC
+    4,             # PF_R
+    dyn_off,       # offset
+    dyn_off,       # vaddr
+    dyn_off,       # paddr
+    len(dyn_data), # filesz
+    len(dyn_data), # memsz
+    8)             # align
+
+# --- ELF header ---
+ELFCLASS64   = 2
+ELFDATA2LSB  = 1
+EV_CURRENT   = 1
+ELFOSABI_NONE = 0
+ET_DYN       = 3
+
+elf_hdr = struct.pack("<4sBBBBBxxxxxxx",
+    b"\x7fELF", ELFCLASS64, ELFDATA2LSB, EV_CURRENT, ELFOSABI_NONE, 0)
+elf_hdr += struct.pack("<HHIQQQIHHHHHH",
+    ET_DYN, MACHINE, EV_CURRENT,
+    0,         # e_entry
+    phdr_off,  # e_phoff
+    0,         # e_shoff (no section headers needed)
+    0,         # e_flags
+    ELF_HDR_SZ, PHDR_SZ, PHDR_CNT,
+    64, 0, 0)  # shentsize, shnum, shstrndx
+
+assert len(elf_hdr) == ELF_HDR_SZ, f"ELF header size mismatch: {len(elf_hdr)}"
+
+# --- Assemble ---
+buf = bytearray(total)
+
+def put(off, data):
+    buf[off:off + len(data)] = data
+
+put(0,           elf_hdr)
+put(phdr_off,    phdr_load)
+put(phdr_off + PHDR_SZ, phdr_dyn)
+put(dynstr_off,  dynstr)
+put(dynsym_off,  dynsym)
+put(gnuh_off,    gnu_hash_data)
+put(dyn_off,     dyn_data)
+
+with open(OUTPATH, "wb") as f:
+    f.write(buf)
+
+print(f"Wrote {total} bytes to {OUTPATH}")
+print(f"  machine:     {'EM_AARCH64' if MACHINE == 183 else 'EM_X86_64'} ({MACHINE})")
+print(f"  setenv hash: 0x{SETENV_HASH:08x}")
+print(f"  bloom bit0:  {bit0}  bit1: {bit1}  → bloom[0]=0x{bloom_val:016x}")
+print(f"  bucket[0]:   0  symoffset: {SYMOFFSET}")
+print(f"  underflow:   0 - {SYMOFFSET} as u32 = 0x{(0 - SYMOFFSET) & 0xFFFFFFFF:08x}")

--- a/injector-integration-tests/apps/empty-gnu-hash-bucket/premapper.c
+++ b/injector-integration-tests/apps/empty-gnu-hash-bucket/premapper.c
@@ -1,0 +1,32 @@
+/* premapper.c
+ *
+ * When loaded via LD_PRELOAD (before libotelinject.so), this library's
+ * constructor maps /trigger.so at a fixed low virtual address (0x1000000).
+ *
+ * Because all ASLR-randomized library addresses are in the 0xc.../0xf... range
+ * on 64-bit kernels, 0x1000000 appears *first* in /proc/self/maps.
+ *
+ * The injector's second-pass scan of /proc/self/maps processes entries from
+ * lowest to highest address, so it reaches the trigger.so entry before libc.
+ * ElfDynLib.lookupAddress("setenv") then hits the crafted empty GNU hash
+ * bucket and panics with "integer overflow".
+ */
+#define _GNU_SOURCE
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+static void __attribute__((constructor(101))) map_trigger(void) {
+    int fd = open("/trigger.so", O_RDONLY);
+    if (fd < 0) return;
+
+    struct stat st;
+    if (fstat(fd, &st) < 0) { close(fd); return; }
+
+    /* 0x1000000 = 16 MB — well below the ASLR mmap range on 64-bit kernels */
+    mmap((void *)0x1000000, (size_t)st.st_size,
+         PROT_READ | PROT_EXEC,
+         MAP_FIXED | MAP_PRIVATE, fd, 0);
+    close(fd);
+}

--- a/injector-integration-tests/apps/empty-gnu-hash-bucket/printenv.c
+++ b/injector-integration-tests/apps/empty-gnu-hash-bucket/printenv.c
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+// A minimal C program that prints the value of a named environment variable.
+// Deliberately uses only libc (stdio, stdlib) and is compiled without -ldl, so
+// libdl.so does not appear in /proc/self/maps at runtime. This reproduces the
+// scenario seen on RHEL 8 and any other pre-glibc-2.34 system where dlsym lives
+// in libdl.so (not in libc.so), and the binary under test does not link libdl.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "error: an environment variable name argument is required\n");
+        return 1;
+    }
+    const char *name = argv[1];
+    const char *value = getenv(name);
+    if (value == NULL) {
+        printf("%s: -", name);
+    } else {
+        printf("%s: %s", name, value);
+    }
+    return 0;
+}

--- a/injector-integration-tests/scripts/run-tests-for-container.sh
+++ b/injector-integration-tests/scripts/run-tests-for-container.sh
@@ -58,6 +58,9 @@ fi
 if [[ "$TEST_SET" = "copy-reloc.tests" ]]; then
   test_app="copy-reloc"
 fi
+if [[ "$TEST_SET" = "empty-gnu-hash-bucket.tests" ]]; then
+  test_app="empty-gnu-hash-bucket"
+fi
 
 # We also use the Node.js test app for non-runtime specific tests (e.g. injector-integration-tests/tests/default.tests
 # etc.), so this is the default Dockerfile.
@@ -127,6 +130,12 @@ case "$test_app" in
     # /usr/local/bin/node carries an R_*_COPY relocation on __environ. We do not provide a musl variant
     # because the tests themselves skip for LIBC=musl: the bug is in the glibc-specific fallback path.
     base_image_run=node:16-bullseye-slim
+    ;;
+  "empty-gnu-hash-bucket")
+    dockerfile_name="injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile"
+    base_image_run=debian:bullseye-slim
+    # We do not provide a different base image depending on the libc flavor: the tests themselves skip for
+    # LIBC=musl because musl uses a different libc-detection path that is not affected by this bug.
     ;;
   *)
     echo "Unknown test app: $test_app"

--- a/injector-integration-tests/tests/empty-gnu-hash-bucket.tests
+++ b/injector-integration-tests/tests/empty-gnu-hash-bucket.tests
@@ -1,0 +1,35 @@
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Regression test for issue #399:
+# panic: integer overflow in ElfDynLib.lookupAddress on empty GNU hash bucket.
+#
+# On glibc < 2.34 (e.g. Debian Bullseye / glibc 2.31), /proc/self/maps shows
+# "libc-2.31.so" not "libc.so.6". The injector's first pass (which matches by
+# libc name) therefore finds nothing and falls through to the second pass, which
+# scans every mapped .so.
+#
+# trigger.so is a crafted ELF shared library with a .gnu.hash section where:
+#   - The bloom filter passes (false positive) for "setenv" (hash 0x1b85483a)
+#   - The corresponding bucket value is 0 (empty)
+#   - chain_index = 0 - symoffset(1) wraps as u32 → panic in ReleaseSafe
+#
+# premapper.so maps trigger.so at 0x1000000 (below the ASLR range) in its
+# constructor, so the second-pass scan encounters it before libc. With
+# LD_PRELOAD="/injector/libotelinject.so:/premapper.so", premapper's constructor
+# runs first (the dynamic linker initialises later-listed entries first when
+# there are no interdependencies), ensuring trigger.so is already mapped when
+# the injector's initEnviron reads /proc/self/maps.
+#
+# This test is glibc-specific; musl uses a different libc-detection path.
+if [ "${LIBC_FLAVOR:-}" != "glibc" ]; then
+  echo "Skipping empty-gnu-hash-bucket tests: these tests are glibc-specific (LIBC_FLAVOR=${LIBC_FLAVOR:-unset})"
+  return 0 2>/dev/null || true
+fi
+
+run_test_case \
+  "empty GNU hash bucket: process survives lookup on empty bucket in second pass" \
+  "app" \
+  "./printenv OTEL_RESOURCE_ATTRIBUTES" \
+  "OTEL_RESOURCE_ATTRIBUTES: k8s.namespace.name=my-namespace,k8s.pod.name=my-pod,k8s.pod.uid=275ecb36-5aa8-4c2a-9c47-d8bb681b9aff,k8s.container.name=test-app" \
+  "LD_PRELOAD=/injector/libotelinject.so:/premapper.so"

--- a/src/elf.zig
+++ b/src/elf.zig
@@ -166,7 +166,14 @@ pub const ElfDynLib = struct {
             }
 
             const bucket_index = hash % gnu_hash_header.nbuckets;
-            const chain_index = gnu_hash_section.buckets[bucket_index] - gnu_hash_header.symoffset;
+            const bucket_value = gnu_hash_section.buckets[bucket_index];
+            if (bucket_value < gnu_hash_header.symoffset) {
+                // Empty bucket (value 0) or any value below symoffset: no symbol in this bucket.
+                // Mirrors glibc's dl-lookup check. Without this guard, the subtraction below
+                // would underflow as u32 and trigger a ReleaseSafe panic (issue #399).
+                return null;
+            }
+            const chain_index = bucket_value - gnu_hash_header.symoffset;
 
             const chains = gnu_hash_section.chain;
             const hash_as_entry: std.elf.gnu_hash.ChainEntry = @bitCast(hash);


### PR DESCRIPTION
## Summary

Fixes #399.

On glibc < 2.34 systems (RHEL 8, Debian Bullseye, …) the injector's second pass over `/proc/self/maps` calls `ElfDynLib.lookupAddress` on every mapped shared object. The GNU hash lookup did not guard against empty buckets (value 0) or bucket values below `symoffset`:

```zig
// before
const chain_index = gnu_hash_section.buckets[bucket_index] - gnu_hash_header.symoffset;
```

If the bloom filter false-positives for a looked-up symbol and the corresponding bucket is empty, this `u32` subtraction underflows and triggers a ReleaseSafe `panic: integer overflow` that aborts the host process with `SIGABRT` before its own code runs — taking down arbitrary system daemons loaded via `ld.so.preload`.

The fix mirrors glibc's `dl-lookup` behaviour: treat any bucket value below `symoffset` as "symbol not in this object" and return `null`.

```zig
// after
const bucket_value = gnu_hash_section.buckets[bucket_index];
if (bucket_value < gnu_hash_header.symoffset) {
    return null;
}
const chain_index = bucket_value - gnu_hash_header.symoffset;
```