### PR TITLE
feat(dotnet): make the minimum .NET major version required for injection configurable

### DIFF
--- a/.chloggen/dotnet-minimum-major-version-configurable.yaml
+++ b/.chloggen/dotnet-minimum-major-version-configurable.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dotnet
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make the minimum .NET major version required for injection configurable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [1]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The injector inspects the `*.runtimeconfig.json` file of the target application and skips the injection of the
+  .NET auto-instrumentation if the application does not target a supported .NET version. The minimum supported .NET
+  major version (previously hardcoded to 8) can now be configured via the configuration file key
+  `dotnet_auto_instrumentation_minimum_dotnet_major_version` or the environment variable
+  `DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION`. The default remains 8, matching the .NET versions
+  supported by the upstream OpenTelemetry .NET auto-instrumentation. Distributions of the .NET auto-instrumentation
+  that support older .NET versions can lower this threshold accordingly.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/dotnet-minimum-major-version-configurable.yaml
+++ b/.chloggen/dotnet-minimum-major-version-configurable.yaml
@@ -10,7 +10,7 @@ component: dotnet
 note: Make the minimum .NET major version required for injection configurable.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [1]
+issues: [409]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ This method requires `root` privileges.
    The values set in the configuration file can be overridden with environment variables.
    - `DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX`: the path to the directory containing the .NET auto-instrumentation
      agent files
+   - `DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION`: the minimum .NET major version an application (as
+     determined by inspecting its `*.runtimeconfig.json` file) needs to target to be eligible for .NET
+     auto-instrumentation; can also be set via the configuration file key
+     `dotnet_auto_instrumentation_minimum_dotnet_major_version`. The default is `8`, matching the .NET versions
+     supported by the upstream OpenTelemetry .NET auto-instrumentation. Distributions of the .NET
+     auto-instrumentation that support older .NET versions can lower this threshold accordingly.
    - `JVM_AUTO_INSTRUMENTATION_AGENT_PATH`: the path to the Java auto-instrumentation agent JAR file
    - `NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH`: the path to the Node.js auto-instrumentation agent registration file
    - `PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX`: the path to the directory containing the Python auto-instrumentation agent files (Python is disabled by default, see [Enabling Auto-Instrumentation for Python](#enabling-auto-instrumentation-for-python))
@@ -168,7 +174,11 @@ Here is an overview of the modifications that the injector will apply:
       In contrast to other runtimes, .NET does not support adding multiple agents.
     * The injector first inspects the adjacent `*.runtimeconfig.json` file of the target application when it is
       available.
-    * The injector stands down if the specified runtime version does not target `net8.0` or later.
+    * The injector stands down if the specified runtime version does not target a supported .NET version. By
+      default, the minimum supported .NET major version is 8, matching the .NET versions supported by the upstream
+      OpenTelemetry .NET auto-instrumentation; it can be changed via the configuration file key
+      `dotnet_auto_instrumentation_minimum_dotnet_major_version` or the environment variable
+      `DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION`.
     * If the `.runtimeconfig.json` file is missing, unreadable, malformed, or missing the expected fields, the
       injector proceeds with additional .NET checks.
     * To reduce the risk of double-instrumentation, the injector then inspects the adjacent `*.deps.json` file of the

--- a/src/config.zig
+++ b/src/config.zig
@@ -24,6 +24,7 @@ const default_config_dir_path = "/etc/opentelemetry/injector/conf.d";
 const config_dir_path_env_var = "OTEL_INJECTOR_CONFIG_DIR";
 
 const dotnet_path_prefix_key = "dotnet_auto_instrumentation_agent_path_prefix";
+const dotnet_minimum_dotnet_major_version_key = "dotnet_auto_instrumentation_minimum_dotnet_major_version";
 const jvm_path_key = "jvm_auto_instrumentation_agent_path";
 const nodejs_path_key = "nodejs_auto_instrumentation_agent_path";
 const python_path_prefix_key = "python_auto_instrumentation_agent_path_prefix";
@@ -33,6 +34,7 @@ const all_agents_env_path_key = "all_auto_instrumentation_agents_env_path";
 const auto_instrumentation_disabled_key = "auto_instrumentation_disabled";
 
 const dotnet_agent_path_prefix_env_var = "DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX";
+const dotnet_minimum_dotnet_major_version_env_var = "DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION";
 const jvm_agent_path_env_var = "JVM_AUTO_INSTRUMENTATION_AGENT_PATH";
 const nodejs_agent_path_env_var = "NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH";
 const python_agent_path_prefix_env_var = "PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX";
@@ -66,6 +68,7 @@ pub const InjectorConfiguration = struct {
     exclude_paths: [][]const u8,
     include_args: [][]const u8,
     exclude_args: [][]const u8,
+    dotnet_auto_instrumentation_minimum_dotnet_major_version: u32,
     dotnet_instrumentation_disabled: bool,
     jvm_instrumentation_disabled: bool,
     nodejs_instrumentation_disabled: bool,
@@ -95,6 +98,11 @@ pub const InjectorConfiguration = struct {
 const ConfigApplier = fn (gpa: std.mem.Allocator, key: []const u8, value: []u8, file_path: []const u8, configuration: *InjectorConfiguration) void;
 
 const default_dotnet_auto_instrumentation_agent_path_prefix = "";
+
+// The upstream OpenTelemetry .NET auto-instrumentation supports .NET 8 or later. Distributions of the .NET
+// auto-instrumentation that support older .NET versions can lower this threshold via the configuration file key
+// dotnet_auto_instrumentation_minimum_dotnet_major_version or the corresponding environment variable.
+pub const default_dotnet_auto_instrumentation_minimum_dotnet_major_version: u32 = 8;
 const default_jvm_auto_instrumentation_agent_path = "";
 const default_nodejs_auto_instrumentation_agent_path = "";
 
@@ -152,6 +160,7 @@ fn createEmptyConfiguration(allocator: std.mem.Allocator) InjectorConfiguration 
         .exclude_paths = &.{},
         .include_args = &.{},
         .exclude_args = &.{},
+        .dotnet_auto_instrumentation_minimum_dotnet_major_version = default_dotnet_auto_instrumentation_minimum_dotnet_major_version,
         .dotnet_instrumentation_disabled = false,
         .jvm_instrumentation_disabled = false,
         .nodejs_instrumentation_disabled = false,
@@ -260,6 +269,7 @@ test "readConfigurationFromPath: loads from the specified path" {
         "/custom/path/to/dotnet/instrumentation",
         configuration.dotnet_auto_instrumentation_agent_path_prefix,
     );
+    try testing.expectEqual(@as(u32, 6), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
     try testing.expectEqualStrings(
         "/custom/path/to/jvm/javaagent.jar",
         configuration.jvm_auto_instrumentation_agent_path,
@@ -300,6 +310,10 @@ test "readConfigurationFromPath: file does not exist, no environment variables" 
     try testing.expectEqual(0, configuration.exclude_paths.len);
     try testing.expectEqual(0, configuration.include_args.len);
     try testing.expectEqual(0, configuration.exclude_args.len);
+    try testing.expectEqual(
+        default_dotnet_auto_instrumentation_minimum_dotnet_major_version,
+        configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version,
+    );
     try test_util.expectWithMessage(!configuration.dotnet_instrumentation_disabled, "!configuration.dotnet_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.jvm_instrumentation_disabled, "!configuration.jvm_instrumentation_disabled");
     try test_util.expectWithMessage(!configuration.nodejs_instrumentation_disabled, "!configuration.nodejs_instrumentation_disabled");
@@ -309,8 +323,9 @@ test "readConfigurationFromPath: file does not exist, no environment variables" 
 test "readConfigurationFromPath: file does not exist, environment variables are set" {
     const allocator = testing.allocator;
 
-    const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
+    const original_environ = try test_util.setStdCEnviron(&[9][]const u8{
         "DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/env/var/dotnet",
+        "DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION=6",
         "JVM_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/env/var/jvm",
         "NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/env/var/nodejs",
         "PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/env/var/python",
@@ -328,6 +343,7 @@ test "readConfigurationFromPath: file does not exist, environment variables are 
         "/path/from/env/var/dotnet",
         configuration.dotnet_auto_instrumentation_agent_path_prefix,
     );
+    try testing.expectEqual(@as(u32, 6), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
     try testing.expectEqualStrings(
         "/path/from/env/var/jvm",
         configuration.jvm_auto_instrumentation_agent_path,
@@ -381,6 +397,7 @@ test "readConfigurationFromPath: all configuration values from file, no environm
         "/custom/path/to/dotnet/instrumentation",
         configuration.dotnet_auto_instrumentation_agent_path_prefix,
     );
+    try testing.expectEqual(@as(u32, 6), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
     try testing.expectEqualStrings(
         "/custom/path/to/jvm/javaagent.jar",
         configuration.jvm_auto_instrumentation_agent_path,
@@ -429,8 +446,9 @@ test "readConfigurationFromPath: override some configuration values from file wi
         try std.fs.path.resolve(allocator, &.{ cwd_path, "unit-test-assets/config/all_values.conf" });
     defer allocator.free(absolute_path_to_config_file);
 
-    const original_environ = try test_util.setStdCEnviron(&[5][]const u8{
+    const original_environ = try test_util.setStdCEnviron(&[6][]const u8{
         "DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/env/var/dotnet",
+        "DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION=9",
         "NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/env/var/nodejs",
         "OTEL_INJECTOR_AUTO_INSTRUMENTATION_DISABLED=python",
         "OTEL_INJECTOR_INCLUDE_PATHS=/path/from/env/var/include1,/path/from/env/var/include2",
@@ -445,6 +463,7 @@ test "readConfigurationFromPath: override some configuration values from file wi
         "/path/from/env/var/dotnet",
         configuration.dotnet_auto_instrumentation_agent_path_prefix,
     );
+    try testing.expectEqual(@as(u32, 9), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
     try testing.expectEqualStrings(
         "/custom/path/to/jvm/javaagent.jar",
         configuration.jvm_auto_instrumentation_agent_path,
@@ -496,6 +515,7 @@ fn createDefaultConfiguration(arena_allocator: std.mem.Allocator) std.mem.Alloca
         .exclude_paths = &.{},
         .include_args = &.{},
         .exclude_args = &.{},
+        .dotnet_auto_instrumentation_minimum_dotnet_major_version = default_dotnet_auto_instrumentation_minimum_dotnet_major_version,
         .dotnet_instrumentation_disabled = false,
         .jvm_instrumentation_disabled = false,
         .nodejs_instrumentation_disabled = false,
@@ -544,6 +564,48 @@ fn applyAutoInstrumentationDisabledValue(trimmed_value: []const u8, source: []co
     }
 }
 
+fn applyDotnetMinimumDotnetMajorVersionValue(value: []const u8, source: []const u8, configuration: *InjectorConfiguration) void {
+    const trimmed_value = std.mem.trim(u8, value, " \t");
+    const parsed_version = std.fmt.parseUnsigned(u32, trimmed_value, 10) catch {
+        print.printWarn(
+            "Ignoring invalid value for {s} from {s}: \"{s}\" - a non-negative integer is required.",
+            .{ dotnet_minimum_dotnet_major_version_key, source, trimmed_value },
+        );
+        return;
+    };
+    configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version = parsed_version;
+}
+
+test "applyDotnetMinimumDotnetMajorVersionValue: parses a valid value" {
+    var configuration = createEmptyConfiguration(testing.allocator);
+    defer configuration.all_auto_instrumentation_agents_env_vars.deinit();
+
+    applyDotnetMinimumDotnetMajorVersionValue("6", "test", &configuration);
+
+    try testing.expectEqual(@as(u32, 6), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
+}
+
+test "applyDotnetMinimumDotnetMajorVersionValue: trims whitespace" {
+    var configuration = createEmptyConfiguration(testing.allocator);
+    defer configuration.all_auto_instrumentation_agents_env_vars.deinit();
+
+    applyDotnetMinimumDotnetMajorVersionValue(" 7\t", "test", &configuration);
+
+    try testing.expectEqual(@as(u32, 7), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
+}
+
+test "applyDotnetMinimumDotnetMajorVersionValue: ignores an invalid value and keeps the default" {
+    var configuration = createEmptyConfiguration(testing.allocator);
+    defer configuration.all_auto_instrumentation_agents_env_vars.deinit();
+
+    applyDotnetMinimumDotnetMajorVersionValue("not-a-number", "test", &configuration);
+
+    try testing.expectEqual(
+        default_dotnet_auto_instrumentation_minimum_dotnet_major_version,
+        configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version,
+    );
+}
+
 fn applyCommaSeparatedPatternsOption(arena_allocator: std.mem.Allocator, setting: *[][]const u8, value: []u8, pattern_name: []const u8, cfg_file_path: []const u8) void {
     const new_patterns = patterns_util.splitByComma(arena_allocator, value) catch |err| {
         print.printError("error parsing {s} value from configuration file {s}: {}", .{ pattern_name, cfg_file_path, err });
@@ -558,6 +620,8 @@ fn applyCommaSeparatedPatternsOption(arena_allocator: std.mem.Allocator, setting
 fn applyKeyValueToGeneralOptions(arena_allocator: std.mem.Allocator, key: []const u8, value: []u8, _cfg_file_path: []const u8, _configuration: *InjectorConfiguration) void {
     if (std.mem.eql(u8, key, dotnet_path_prefix_key)) {
         _configuration.dotnet_auto_instrumentation_agent_path_prefix = value;
+    } else if (std.mem.eql(u8, key, dotnet_minimum_dotnet_major_version_key)) {
+        applyDotnetMinimumDotnetMajorVersionValue(value, _cfg_file_path, _configuration);
     } else if (std.mem.eql(u8, key, jvm_path_key)) {
         _configuration.jvm_auto_instrumentation_agent_path = value;
     } else if (std.mem.eql(u8, key, nodejs_path_key)) {
@@ -778,6 +842,7 @@ fn copyToPermanentlyAllocatedHeap(
         .exclude_paths = try copyStringArray(allocator, preliminary_configuration.exclude_paths),
         .include_args = try copyStringArray(allocator, preliminary_configuration.include_args),
         .exclude_args = try copyStringArray(allocator, preliminary_configuration.exclude_args),
+        .dotnet_auto_instrumentation_minimum_dotnet_major_version = preliminary_configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version,
         .dotnet_instrumentation_disabled = preliminary_configuration.dotnet_instrumentation_disabled,
         .jvm_instrumentation_disabled = preliminary_configuration.jvm_instrumentation_disabled,
         .nodejs_instrumentation_disabled = preliminary_configuration.nodejs_instrumentation_disabled,
@@ -2028,6 +2093,9 @@ fn readConfigurationFromEnvironment(arena_allocator: std.mem.Allocator, configur
         };
         configuration.dotnet_auto_instrumentation_agent_path_prefix = dotnet_value;
     }
+    if (getenv_fn(arena_allocator, dotnet_minimum_dotnet_major_version_env_var)) |value| {
+        applyDotnetMinimumDotnetMajorVersionValue(value, dotnet_minimum_dotnet_major_version_env_var, configuration);
+    }
     if (getenv_fn(arena_allocator, jvm_agent_path_env_var)) |value| {
         const trimmed_value = std.mem.trim(u8, value, " \t\r\n");
         const jvm_value = std.fmt.allocPrint(arena_allocator, "{s}", .{trimmed_value}) catch |err| {
@@ -2156,8 +2224,9 @@ test "readConfigurationFromEnvironment: all values" {
     defer arena.deinit();
     const arena_allocator = arena.allocator();
 
-    const original_environ = try test_util.setStdCEnviron(&[8][]const u8{
+    const original_environ = try test_util.setStdCEnviron(&[9][]const u8{
         "DOTNET_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/env/var/dotnet",
+        "DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION=6",
         "JVM_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/env/var/jvm",
         "NODEJS_AUTO_INSTRUMENTATION_AGENT_PATH=/path/from/env/var/nodejs",
         "PYTHON_AUTO_INSTRUMENTATION_AGENT_PATH_PREFIX=/path/from/env/var/python",
@@ -2175,6 +2244,7 @@ test "readConfigurationFromEnvironment: all values" {
         "/path/from/env/var/dotnet",
         configuration.dotnet_auto_instrumentation_agent_path_prefix,
     );
+    try testing.expectEqual(@as(u32, 6), configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version);
     try testing.expectEqualStrings(
         "/path/from/env/var/jvm",
         configuration.jvm_auto_instrumentation_agent_path,

--- a/src/dotnet.zig
+++ b/src/dotnet.zig
@@ -100,10 +100,20 @@ pub fn getDotnetValues(
     gpa: std.mem.Allocator,
     configuration: config.InjectorConfiguration,
 ) ?DotnetValues {
-    return doGetDotnetValues(gpa, configuration.dotnet_auto_instrumentation_agent_path_prefix, configuration.dotnet_instrumentation_disabled);
+    return doGetDotnetValues(
+        gpa,
+        configuration.dotnet_auto_instrumentation_agent_path_prefix,
+        configuration.dotnet_instrumentation_disabled,
+        configuration.dotnet_auto_instrumentation_minimum_dotnet_major_version,
+    );
 }
 
-fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_instrumentation_disabled: bool) ?DotnetValues {
+fn doGetDotnetValues(
+    gpa: std.mem.Allocator,
+    dotnet_path_prefix: []u8,
+    dotnet_instrumentation_disabled: bool,
+    minimum_dotnet_major_version: u32,
+) ?DotnetValues {
     if (dotnet_instrumentation_disabled or dotnet_path_prefix.len == 0) {
         print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because it has been explicitly disabled.", .{});
         return null;
@@ -122,7 +132,7 @@ fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_in
         return cached_dotnet_values.values;
     }
 
-    if (!shouldInjectDotnet(gpa)) {
+    if (!shouldInjectDotnet(gpa, minimum_dotnet_major_version)) {
         cached_dotnet_values = .{
             .values = null,
             .done = true,
@@ -194,7 +204,7 @@ fn doGetDotnetValues(gpa: std.mem.Allocator, dotnet_path_prefix: []u8, dotnet_in
     unreachable;
 }
 
-fn shouldInjectDotnet(allocator: std.mem.Allocator) bool {
+fn shouldInjectDotnet(allocator: std.mem.Allocator, minimum_dotnet_major_version: u32) bool {
     if (findConflictingPreExistingDotnetEnvVar()) |conflicting_env_var_name| {
         print.printInfo(
             "Skipping the injection of the .NET OpenTelemetry instrumentation because {s} is already set.",
@@ -240,12 +250,12 @@ fn shouldInjectDotnet(allocator: std.mem.Allocator) bool {
     };
     defer allocator.free(runtimeconfig_content);
 
-    const runtimeconfig_targets_modern_dotnet = runtimeConfigTargetsModernDotnet(allocator, runtimeconfig_content) catch |err| {
+    const runtimeconfig_targets_supported_dotnet = runtimeConfigTargetsSupportedDotnet(allocator, runtimeconfig_content, minimum_dotnet_major_version) catch |err| {
         print.printDebug("Proceeding with the injection of the .NET OpenTelemetry instrumentation. Could not parse {s} safely: {}", .{ metadata_paths.runtimeconfig_path, err });
         return true;
     };
-    if (!runtimeconfig_targets_modern_dotnet) {
-        print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because {s} does not target a supported .NET runtime.", .{metadata_paths.runtimeconfig_path});
+    if (!runtimeconfig_targets_supported_dotnet) {
+        print.printInfo("Skipping the injection of the .NET OpenTelemetry instrumentation because {s} does not target a supported .NET runtime (minimum supported .NET major version: {d}).", .{ metadata_paths.runtimeconfig_path, minimum_dotnet_major_version });
         return false;
     }
 
@@ -370,7 +380,7 @@ fn jsonObjectKeyLooksLikeOpenTelemetryDependency(key: []const u8) bool {
     return std.mem.startsWith(u8, dependency_name, opentelemetry_dependency_prefix);
 }
 
-fn runtimeConfigTargetsModernDotnet(allocator: std.mem.Allocator, content: []const u8) !bool {
+fn runtimeConfigTargetsSupportedDotnet(allocator: std.mem.Allocator, content: []const u8, minimum_dotnet_major_version: u32) !bool {
     var parsed = try std.json.parseFromSlice(std.json.Value, allocator, content, .{});
     defer parsed.deinit();
 
@@ -391,10 +401,10 @@ fn runtimeConfigTargetsModernDotnet(allocator: std.mem.Allocator, content: []con
         else => return true,
     };
 
-    return tfmTargetsModernDotnet(tfm_str);
+    return tfmTargetsSupportedDotnet(tfm_str, minimum_dotnet_major_version);
 }
 
-fn tfmTargetsModernDotnet(tfm: []const u8) bool {
+fn tfmTargetsSupportedDotnet(tfm: []const u8, minimum_dotnet_major_version: u32) bool {
     if (!std.mem.startsWith(u8, tfm, "net")) return false;
 
     const rest = tfm[3..];
@@ -408,7 +418,7 @@ fn tfmTargetsModernDotnet(tfm: []const u8) bool {
     const major_str = rest[0..dot_index];
     const major = std.fmt.parseUnsigned(u32, major_str, 10) catch return false;
 
-    return major >= 8;
+    return major >= minimum_dotnet_major_version;
 }
 
 test "doGetDotnetValues: should return null value if the libc flavor has not been set" {
@@ -420,7 +430,7 @@ test "doGetDotnetValues: should return null value if the libc flavor has not bee
     defer allocator.free(path);
 
     // libc_info is null after _resetState()
-    const dotnet_values = doGetDotnetValues(allocator, path, false);
+    const dotnet_values = doGetDotnetValues(allocator, path, false, 8);
     try test_util.expectWithMessage(dotnet_values == null, "dotnet_values == null");
 }
 
@@ -433,7 +443,7 @@ test "doGetDotnetValues: should return null value if dotnet_instrumentation_disa
     defer allocator.free(path);
 
     libc_info = test_util.testLibcInfo(.GNU);
-    const dotnet_values = doGetDotnetValues(allocator, path, true);
+    const dotnet_values = doGetDotnetValues(allocator, path, true, 8);
     try test_util.expectWithMessage(dotnet_values == null, "dotnet_values == null");
 }
 
@@ -446,7 +456,7 @@ test "doGetDotnetValues: should return null value if dotnet_path_prefix is the e
     defer allocator.free(path);
 
     libc_info = test_util.testLibcInfo(.GNU);
-    const dotnet_values = doGetDotnetValues(allocator, path, false);
+    const dotnet_values = doGetDotnetValues(allocator, path, false, 8);
     try test_util.expectWithMessage(dotnet_values == null, "dotnet_values == null");
 }
 
@@ -459,7 +469,7 @@ test "doGetDotnetValues: should return null value if the profiler path cannot be
     defer allocator.free(path);
 
     libc_info = test_util.testLibcInfo(.GNU);
-    const dotnet_values = doGetDotnetValues(allocator, path, false);
+    const dotnet_values = doGetDotnetValues(allocator, path, false, 8);
     try test_util.expectWithMessage(dotnet_values == null, "dotnet_values == null");
 }
 
@@ -475,7 +485,7 @@ test "doGetDotnetValues: should return null value if conflicting .NET env var al
     defer allocator.free(path);
 
     libc_info = test_util.testLibcInfo(.GNU);
-    const dotnet_values = doGetDotnetValues(allocator, path, false);
+    const dotnet_values = doGetDotnetValues(allocator, path, false, 8);
     try test_util.expectWithMessage(dotnet_values == null, "dotnet_values == null");
 }
 
@@ -613,7 +623,7 @@ test "createDotnetMetadataPaths: apphost path produces deps path" {
     try testing.expectEqualStrings("/app/MyApp.runtimeconfig.json", metadata_paths.runtimeconfig_path);
 }
 
-test "runtimeConfigTargetsModernDotnet: true for net8.0 Microsoft.NETCore.App" {
+test "runtimeConfigTargetsSupportedDotnet: true for net8.0 Microsoft.NETCore.App" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -626,10 +636,10 @@ test "runtimeConfigTargetsModernDotnet: true for net8.0 Microsoft.NETCore.App" {
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig should qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: true for ASP.NET Core runtimeconfig" {
+test "runtimeConfigTargetsSupportedDotnet: true for ASP.NET Core runtimeconfig" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -642,10 +652,10 @@ test "runtimeConfigTargetsModernDotnet: true for ASP.NET Core runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig should qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: false for net7.0 runtimeconfig" {
+test "runtimeConfigTargetsSupportedDotnet: false for net7.0 runtimeconfig" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -658,10 +668,51 @@ test "runtimeConfigTargetsModernDotnet: false for net7.0 runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage(!(try runtimeConfigTargetsModernDotnet(testing.allocator, content)), "runtimeconfig should not qualify");
+    try test_util.expectWithMessage(!(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8)), "runtimeconfig should not qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: true for incomplete runtimeconfig" {
+test "runtimeConfigTargetsSupportedDotnet: false for net6.0 runtimeconfig with the default minimum major version" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net6.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "6.0.0"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage(!(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8)), "runtimeconfig should not qualify");
+}
+
+test "runtimeConfigTargetsSupportedDotnet: true for net6.0 runtimeconfig when the minimum major version is lowered to 6" {
+    const content =
+        \\{
+        \\  "runtimeOptions": {
+        \\    "tfm": "net6.0",
+        \\    "framework": {
+        \\      "name": "Microsoft.NETCore.App",
+        \\      "version": "6.0.36"
+        \\    }
+        \\  }
+        \\}
+    ;
+
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 6), "runtimeconfig should qualify");
+}
+
+test "tfmTargetsSupportedDotnet: respects the configured minimum major version" {
+    try test_util.expectWithMessage(tfmTargetsSupportedDotnet("net8.0", 8), "net8.0 should qualify with minimum 8");
+    try test_util.expectWithMessage(!tfmTargetsSupportedDotnet("net6.0", 8), "net6.0 should not qualify with minimum 8");
+    try test_util.expectWithMessage(tfmTargetsSupportedDotnet("net6.0", 6), "net6.0 should qualify with minimum 6");
+    try test_util.expectWithMessage(tfmTargetsSupportedDotnet("net8.0", 6), "net8.0 should qualify with minimum 6");
+    try test_util.expectWithMessage(!tfmTargetsSupportedDotnet("net5.0", 6), "net5.0 should not qualify with minimum 6");
+    try test_util.expectWithMessage(!tfmTargetsSupportedDotnet("net472", 6), "legacy dotless TFMs should never qualify");
+}
+
+test "runtimeConfigTargetsSupportedDotnet: true for incomplete runtimeconfig" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -670,14 +721,14 @@ test "runtimeConfigTargetsModernDotnet: true for incomplete runtimeconfig" {
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig with no tfm should proceed with injection");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig with no tfm should proceed with injection");
 }
 
-test "runtimeConfigTargetsModernDotnet: rejects malformed json" {
-    try testing.expectError(error.UnexpectedEndOfInput, runtimeConfigTargetsModernDotnet(testing.allocator, "{"));
+test "runtimeConfigTargetsSupportedDotnet: rejects malformed json" {
+    try testing.expectError(error.UnexpectedEndOfInput, runtimeConfigTargetsSupportedDotnet(testing.allocator, "{", 8));
 }
 
-test "runtimeConfigTargetsModernDotnet: true for net9.0 Microsoft.NETCore.App" {
+test "runtimeConfigTargetsSupportedDotnet: true for net9.0 Microsoft.NETCore.App" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -690,10 +741,10 @@ test "runtimeConfigTargetsModernDotnet: true for net9.0 Microsoft.NETCore.App" {
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig should qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: true for net11.0 future multi-digit major" {
+test "runtimeConfigTargetsSupportedDotnet: true for net11.0 future multi-digit major" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -706,10 +757,10 @@ test "runtimeConfigTargetsModernDotnet: true for net11.0 future multi-digit majo
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig should qualify");
 }
 
-test "runtimeConfigTargetsModernDotnet: true for OS-specific TFM net8.0-windows" {
+test "runtimeConfigTargetsSupportedDotnet: true for OS-specific TFM net8.0-windows" {
     const content =
         \\{
         \\  "runtimeOptions": {
@@ -722,7 +773,7 @@ test "runtimeConfigTargetsModernDotnet: true for OS-specific TFM net8.0-windows"
         \\}
     ;
 
-    try test_util.expectWithMessage(try runtimeConfigTargetsModernDotnet(testing.allocator, content), "runtimeconfig should qualify");
+    try test_util.expectWithMessage(try runtimeConfigTargetsSupportedDotnet(testing.allocator, content, 8), "runtimeconfig should qualify");
 }
 
 test "depsJsonContainsOpenTelemetryDependency: false when no OpenTelemetry packages are present" {

--- a/src/ruby.zig
+++ b/src/ruby.zig
@@ -395,6 +395,7 @@ fn testConfiguration(path_prefix: []const u8, disabled: bool) config.InjectorCon
         .exclude_paths = &.{},
         .include_args = &.{},
         .exclude_args = &.{},
+        .dotnet_auto_instrumentation_minimum_dotnet_major_version = config.default_dotnet_auto_instrumentation_minimum_dotnet_major_version,
         .dotnet_instrumentation_disabled = false,
         .jvm_instrumentation_disabled = false,
         .nodejs_instrumentation_disabled = false,

--- a/unit-test-assets/config/all_values.conf
+++ b/unit-test-assets/config/all_values.conf
@@ -1,4 +1,5 @@
 dotnet_auto_instrumentation_agent_path_prefix=/custom/path/to/dotnet/instrumentation
+dotnet_auto_instrumentation_minimum_dotnet_major_version=6
 jvm_auto_instrumentation_agent_path=/custom/path/to/jvm/javaagent.jar
 nodejs_auto_instrumentation_agent_path=/custom/path/to/nodejs/node_modules/@opentelemetry/auto-instrumentations-node/build/src/register.js
 python_auto_instrumentation_agent_path_prefix=/custom/path/to/python


### PR DESCRIPTION
## Description

The injector inspects the `*.runtimeconfig.json` file of the target application and skips the injection of the .NET auto-instrumentation if the application does not target a supported .NET version. Previously, the minimum supported .NET major version was hardcoded to `8`, matching the .NET versions supported by the upstream OpenTelemetry .NET auto-instrumentation.

Distributions of the .NET auto-instrumentation that support older .NET versions need to be able to lower this threshold. This change makes it configurable via:

- Configuration file key: `dotnet_auto_instrumentation_minimum_dotnet_major_version`
- Environment variable: `DOTNET_AUTO_INSTRUMENTATION_MINIMUM_DOTNET_MAJOR_VERSION`

The default remains `8`, so there is no change in behavior for existing users.

## Changes

- `src/config.zig`: adds parsing and validation for the new `dotnet_auto_instrumentation_minimum_dotnet_major_version` config key and corresponding env var
- `src/dotnet.zig`: threads the configurable minimum version through the .NET version check logic, replacing the hardcoded `8`
- `README.md`: documents the new configuration key and env var
- `unit-test-assets/config/all_values.conf`: adds the new key to the exhaustive test config file
- `.chloggen/dotnet-minimum-major-version-configurable.yaml`: changelog entry

First PR related with #406