### PR TITLE
test(integration): fix tests based on Debian Bullseye

### DIFF
--- a/injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile
+++ b/injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile
@@ -4,9 +4,14 @@
 # Regression test for issue #399:
 # "panic: integer overflow in ElfDynLib.lookupAddress on empty GNU hash bucket"
 #
-# debian:bullseye-slim ships glibc 2.31. On glibc < 2.34, /proc/self/maps shows
-# "libc-2.31.so" not "libc.so.6", so the injector's first pass finds nothing and
-# the second pass scans ALL mapped .so files.
+# The Red Hat UBI 8 base image ships glibc 2.28. On glibc < 2.34,
+# /proc/self/maps shows "libc-2.28.so" not "libc.so.6", so the injector's first
+# pass finds nothing and the second pass scans ALL mapped .so files.
+#
+# Note: this used to be debian:bullseye-slim (glibc 2.31), but Debian 11 has
+# reached its end of life, so its apt repositories no longer work (expired
+# Release files, packages removed from the security pool). UBI 8 is supported
+# until 2029.
 #
 # A crafted library (trigger.so) has a .gnu.hash section where the bloom filter
 # passes (false positive) for "setenv" but the corresponding bucket value is 0
@@ -19,7 +24,7 @@
 # (the dynamic linker initialises later entries first when there are no inter-
 # library dependencies), ensuring trigger.so is already mapped when the injector's
 # initEnviron is called.
-ARG base_image_run="debian:bullseye-slim@sha256:0083feb8da4f624e3a0245e7752af2517d4b81d8b8db50c725644672a132a31b"
+ARG base_image_run="registry.access.redhat.com/ubi8/ubi:8.10@sha256:2dcfc23b79d88fdaeefc6ed0cfb144e41dca600bfa73c38ab5d8dca5b05d1b7f"
 FROM ${base_image_run}
 
 ARG injector_binary
@@ -28,9 +33,8 @@ RUN if [ -z "$injector_binary" ]; then \
       exit 1; \
     fi
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libc6-dev python3 \
-    && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc glibc-devel python3 \
+    && dnf clean all
 
 RUN mkdir -p /etc/opentelemetry/injector/conf.d && chmod -R 777 /etc/opentelemetry
 

--- a/injector-integration-tests/apps/no-libdl/Dockerfile
+++ b/injector-integration-tests/apps/no-libdl/Dockerfile
@@ -1,12 +1,19 @@
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
-# debian:bullseye-slim ships glibc 2.31. On glibc < 2.34, dlsym is exported by
-# libdl.so, not by libc.so itself (the two were merged in glibc 2.34). The test
-# app is a plain C binary compiled without -ldl, so libdl.so never appears in
-# /proc/self/maps. This combination reproduces the libc-detection failure seen
-# on RHEL 8 and similar pre-glibc-2.34 systems when a binary does not link libdl.
-ARG base_image_run="debian:bullseye-slim@sha256:0083feb8da4f624e3a0245e7752af2517d4b81d8b8db50c725644672a132a31b"
+# The Red Hat UBI 8 base image ships glibc 2.28. On glibc < 2.34, dlsym is
+# exported by libdl.so, not by libc.so itself (the two were merged in glibc
+# 2.34). The test app is a plain C binary compiled without -ldl, so libdl.so
+# never appears in /proc/self/maps. This combination reproduces the
+# libc-detection failure seen on RHEL 8 and similar pre-glibc-2.34 systems when
+# a binary does not link libdl.
+#
+# Note: this used to be debian:bullseye-slim (glibc 2.31), but Debian 11 has
+# reached its end of life, so its apt repositories no longer work (expired
+# Release files, packages removed from the security pool). UBI 8 is supported
+# until 2029 and is a closer match for the RHEL 8 systems the bug was reported
+# on anyway.
+ARG base_image_run="registry.access.redhat.com/ubi8/ubi:8.10@sha256:2dcfc23b79d88fdaeefc6ed0cfb144e41dca600bfa73c38ab5d8dca5b05d1b7f"
 FROM ${base_image_run}
 
 ARG injector_binary
@@ -15,9 +22,8 @@ RUN if [ -z "$injector_binary" ]; then \
       exit 1; \
     fi
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends gcc libc6-dev \
-    && rm -rf /var/lib/apt/lists/*
+RUN dnf install -y gcc glibc-devel \
+    && dnf clean all
 
 RUN mkdir -p /etc/opentelemetry/injector/conf.d && chmod -R 777 /etc/opentelemetry
 

--- a/injector-integration-tests/scripts/run-tests-for-container.sh
+++ b/injector-integration-tests/scripts/run-tests-for-container.sh
@@ -116,7 +116,8 @@ case "$test_app" in
     ;;
   "no-libdl")
     dockerfile_name="injector-integration-tests/apps/no-libdl/Dockerfile"
-    base_image_run=debian:bullseye-slim
+    # UBI 8 provides glibc 2.28 (i.e. < 2.34, where libdl was still separate from libc), see the Dockerfile.
+    base_image_run=registry.access.redhat.com/ubi8/ubi:8.10
     # We do not provide a different base image depending on the libc flavor: the tests themselves skip for LIBC=musl
     # because musl uses a different libc-detection path that is not affected by this bug.
     ;;
@@ -133,7 +134,8 @@ case "$test_app" in
     ;;
   "empty-gnu-hash-bucket")
     dockerfile_name="injector-integration-tests/apps/empty-gnu-hash-bucket/Dockerfile"
-    base_image_run=debian:bullseye-slim
+    # UBI 8 provides glibc 2.28 (i.e. < 2.34, so /proc/self/maps shows libc-2.28.so, not libc.so.6), see the Dockerfile.
+    base_image_run=registry.access.redhat.com/ubi8/ubi:8.10
     # We do not provide a different base image depending on the libc flavor: the tests themselves skip for
     # LIBC=musl because musl uses a different libc-detection path that is not affected by this bug.
     ;;

--- a/injector-integration-tests/scripts/run-tests-within-container.sh
+++ b/injector-integration-tests/scripts/run-tests-within-container.sh
@@ -44,6 +44,19 @@ if [ ! -f $injector_binary ]; then
   exit 1
 fi
 
+exit_code=0
+
+# Collects the labels of all failed test cases, one per line, so that they can be listed at the end of the test set.
+failed_test_cases=""
+
+# Marks the test set as failed and remembers the label of the failed test case for the summary at the end of the test
+# set.
+record_failed_test_case() {
+  exit_code=1
+  failed_test_cases="$failed_test_cases$1
+"
+}
+
 # Runs one test case. Usage:
 #
 #   run_test_case $test_case_label $working_dir $test_app_command $expected_output $env_vars
@@ -195,21 +208,21 @@ run_test_case() {
     echo "received exit code: $test_exit_code"
     echo "output: $test_output"
     echo "--- end of output"
-    exit_code=1
+    record_failed_test_case "$test_case_label (crashed)"
   elif [ "$test_output" != "$expected" ]; then
     printf "${RED}test \"%s\" failed:${NC}\n" "$test_case_label"
     echo "test command: $full_command"
     echo "expected: $expected"
     echo "actual:   $test_output"
     echo "--- end of output"
-    exit_code=1
+    record_failed_test_case "$test_case_label"
   elif [ "$check_stderr" = "true" ] && [ "$test_stderr" != "$expected_stderr" ]; then
     printf "${RED}test \"%s\" failed (stderr mismatch):${NC}\n" "$test_case_label"
     echo "test command: $full_command"
     echo "expected stderr: $expected_stderr"
     echo "actual stderr:   $test_stderr"
     echo "--- end of output"
-    exit_code=1
+    record_failed_test_case "$test_case_label (stderr mismatch)"
   else
     printf "${GREEN}test \"%s\" successful${NC}\n" "$test_case_label"
     if [ "${VERBOSE:-}" = "true" ]; then
@@ -220,10 +233,16 @@ run_test_case() {
   fi
 }
 
-exit_code=0
-
 # shellcheck source=injector-integration-tests/tests/default.tests
 . "tests/${TEST_SET:-default.tests}"
+
+if [ $exit_code != 0 ]; then
+  echo
+  printf "${RED}Test cases with failures in test set %s:${NC}\n" "${TEST_SET:-default.tests}"
+  printf '%s' "$failed_test_cases" | while IFS= read -r failed_test_case; do
+    printf "${RED}- %s${NC}\n" "$failed_test_case"
+  done
+fi
 
 exit $exit_code
 

--- a/injector-integration-tests/scripts/test-all.sh
+++ b/injector-integration-tests/scripts/test-all.sh
@@ -95,6 +95,7 @@ run_tests_for_architecture_and_libc_flavor() {
   echo ----------------------------------------
 
   test_exit_code=0
+  local failed_test_sets=()
   for test_set in "${all_test_sets[@]}"; do
     local test_set_name="${test_set%.tests}"
     if [[ -n "${test_sets[0]}" ]]; then
@@ -105,6 +106,9 @@ run_tests_for_architecture_and_libc_flavor() {
     fi
 
     run_test_set_for_architecture_and_libc_flavor "$arch" "$libc" "$test_set"
+    if [[ $test_exit_code_last_test_set -ne 0 ]]; then
+      failed_test_sets+=("$test_set_name")
+    fi
     if [[ $test_exit_code_last_test_set -gt $test_exit_code ]]; then
       test_exit_code=$test_exit_code_last_test_set
     fi
@@ -113,9 +117,15 @@ run_tests_for_architecture_and_libc_flavor() {
   echo
   echo ----------------------------------------
   if [ $test_exit_code != 0 ]; then
-    printf "${RED}tests for %s/%s failed (see above for details)${NC}\n" "$arch" "$libc"
+    printf "${RED}Tests for %s/%s have failed, test sets with failures:${NC}\n" "$arch" "$libc"
+    for failed_test_set in "${failed_test_sets[@]}"; do
+      printf "${RED}- %s${NC}\n" "$failed_test_set"
+    done
+    printf "${RED}\nSee above for details.${NC}\n"
     global_exit_code=1
-    summary="$summary\n$arch/$libc:\t${RED}failed${NC}"
+    local failed_test_sets_joined
+    failed_test_sets_joined=$(printf ", %s" "${failed_test_sets[@]}")
+    summary="$summary\n$arch/$libc:\t${RED}failed (failed test sets: ${failed_test_sets_joined:2})${NC}"
   else
     printf "${GREEN}tests for %s/%s were successful${NC}\n" "$arch" "$libc"
     summary="$summary\n$arch/$libc:\t${GREEN}ok${NC}"


### PR DESCRIPTION
Debian Bullseye fell out of LTS support end of August 2026. The container images for the integration tests relying on this version can no longer be built:
  Release file for
  http://deb.debian.org/debian-security/dists/bullseye-security/InRelease
  is expired

We still need a distro with a fairly old glibc though, since the test cases are specifically for a regression that only happens in older glibc where the main libc so file does not include dlsym.

This replaces debian:bullseye-slim with a Red Hat UBI 8 base image, which ships glibc 2.28. UBI 8 is supported until 2029.

I also verified that the tests are still valid by temporarily removing their respective fixes, and check that they actually fail.

Additionally, this improves the test script's output, to make it easier to locate the actual failures in the fairly large output of the full test run.

- After running all tests of a test set, list the failed test cases.
- After running all test sets for a libc flavor, list the test sets with failed test cases.
- List the failed test sets in the final summary as well.