### PR TITLE
ci: create version bump PR when a new Zig version is available

### DIFF
--- a/.github/workflows/scripts/update-zig.sh
+++ b/.github/workflows/scripts/update-zig.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Checks whether a new stable Zig release is available and, if so, opens a pull request that updates the two Zig
+# version references in this repository: ZIG_VERSION in ./zig-version and .minimum_zig_version in ./build.zig.zon.
+#
+# The pull request deliberately changes nothing else. It does not attempt to migrate the code base to the new Zig
+# version, that can hardly be automated. The pull request is only meant as a signal to the maintainers that a new Zig
+# release exists, and as a starting point for the migration. Its CI run will usually fail, that is expected.
+#
+# This is invoked from the update-zig.yaml workflow.
+
+set -euo pipefail
+
+for executable in curl gh git jq; do
+  if ! command -v "$executable" &> /dev/null; then
+    echo "Error: the $executable executable is not available." >&2
+    exit 1
+  fi
+done
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "Error: the GITHUB_REPOSITORY environment variable is not set." >&2
+  exit 1
+fi
+
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+
+# Reads the Zig version that the repository currently uses. This also verifies that the two version references are in
+# sync and fails if they are not: updating both of them to a new version would silently paper over the discrepancy, so
+# it has to be resolved manually first. The same check runs as part of "make lint".
+current_version=$(scripts/zig-version-check.sh)
+
+# The download index on ziglang.org is the authoritative source for Zig releases, see
+# https://ziglang.org/download/. The GitHub repository ziglang/zig is only a mirror of
+# https://codeberg.org/ziglang/zig and is not a usable source: it has neither a tag nor a GitHub release for 0.16.0,
+# and "gh api repos/ziglang/zig/releases/latest" still reports 0.15.1.
+index_json=$(curl -sS --fail --retry 3 https://ziglang.org/download/index.json)
+
+# Matches a stable Zig version like "0.16.0". Development builds ("0.17.0-dev.2085+5e36170b5") and release candidates
+# deliberately do not match.
+zig_version_regex='[0-9]+\.[0-9]+\.[0-9]+'
+
+# The index has one entry per stable release, plus a "master" entry for the current development build. Every entry is
+# reduced to its version and only stable versions are kept, which excludes "master" and any release candidate.
+latest_version=$(
+  jq -r 'to_entries[] | .value.version // .key' <<< "$index_json" |
+    grep -E "^${zig_version_regex}$" |
+    sort -V |
+    tail -n 1 ||
+    true
+)
+if [[ -z "$latest_version" ]]; then
+  echo "Error: cannot determine the latest stable Zig release from https://ziglang.org/download/index.json." >&2
+  exit 1
+fi
+
+echo "current Zig version:       $current_version"
+echo "latest stable Zig release: $latest_version"
+
+newer_version=$(printf '%s\n%s\n' "$current_version" "$latest_version" | sort -V | tail -n 1)
+if [[ "$latest_version" == "$current_version" || "$newer_version" != "$latest_version" ]]; then
+  echo "No update necessary, the Zig version is up to date."
+  exit 0
+fi
+
+branch_name="update-zig-${latest_version}"
+
+# An open pull request for this Zig version means that the maintainers have already been notified about this release
+# and there is nothing left to do, so stop here without failing the run.
+existing_pr=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$branch_name" --state open --json url --jq '.[0].url // empty')
+if [[ -n "$existing_pr" ]]; then
+  echo "The pull request ${existing_pr} updates Zig to ${latest_version} already. Stopping here."
+  exit 0
+fi
+
+echo "Updating the Zig version from ${current_version} to ${latest_version}."
+
+zig_version_file=zig-version
+build_zig_zon_file=build.zig.zon
+sed -i.bak -E "s/^ZIG_VERSION=${zig_version_regex}$/ZIG_VERSION=${latest_version}/" "$zig_version_file"
+rm -f "${zig_version_file}.bak"
+sed -i.bak -E "s/(\.minimum_zig_version = \")${zig_version_regex}(\")/\1${latest_version}\2/" "$build_zig_zon_file"
+rm -f "${build_zig_zon_file}.bak"
+
+mapfile -t changed_files < <(git diff --name-only -- "$zig_version_file" "$build_zig_zon_file")
+if [[ ${#changed_files[@]} -ne 2 ]]; then
+  echo "Error: expected ./${zig_version_file} and ./${build_zig_zon_file} to be updated to ${latest_version}, but ${#changed_files[@]} file(s) have been changed: ${changed_files[*]}" >&2
+  exit 1
+fi
+
+echo
+echo git diff:
+git --no-pager diff -- "${changed_files[@]}"
+echo
+
+# Base commit that the new branch will be based on.
+base_sha=$(git rev-parse HEAD)
+
+# There is no open pull request for this version (verified above), but the branch can still exist: an earlier run may
+# have failed between creating the branch and creating the pull request, or a pull request for this version has been
+# closed without merging it. Creating a ref that already exists fails, so delete it and start over from the current
+# base commit.
+if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${branch_name}" > /dev/null 2>&1; then
+  echo "Deleting the leftover branch \"${branch_name}\", which has no open pull request."
+  gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" > /dev/null
+fi
+
+# Everything from here on can fail halfway through, leaving a branch without a pull request behind. Delete the branch
+# again in that case, so the next run starts from a clean slate and actually retries the notification.
+branch_created=false
+cleanup_branch() {
+  if [[ "$branch_created" == true ]]; then
+    echo "The run failed before the pull request has been created, deleting the branch \"${branch_name}\" again." >&2
+    gh api --method DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/${branch_name}" > /dev/null || true
+  fi
+}
+trap cleanup_branch EXIT
+
+# createCommitOnBranch can only commit onto a branch that already exists. Create the pull request branch at the base
+# commit; we have made sure above that the branch does not exist yet.
+gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+  -f ref="refs/heads/${branch_name}" \
+  -f sha="${base_sha}" > /dev/null
+branch_created=true
+
+commit_message="chore(deps): update Zig to ${latest_version}"
+commit_body=$(
+  cat << EOF
+Updates the two Zig version references to ${latest_version}.
+EOF
+)
+
+# Let "gh api graphql"/createCommitOnBranch create the commit via the GitHub API rather than "git commit"/"git push",
+# so the commit is automatically signed.
+# Note: expectedHeadOid is an optimistic lock: the branch tip must still be at base_sha (it is, we just created it).
+additions=$(
+  for file in "${changed_files[@]}"; do
+    # Reading from stdin and stripping the line breaks afterwards keeps this working with both GNU base64 (which wraps
+    # at 76 characters unless -w0 is given) and BSD base64 (which has no -w and needs -i for a file argument).
+    jq -n --arg path "$file" --arg contents "$(base64 < "$file" | tr -d '\n')" '{path: $path, contents: $contents}'
+  done | jq -s '.'
+)
+
+jq -n \
+  --arg repo "$GITHUB_REPOSITORY" \
+  --arg branch "$branch_name" \
+  --arg headline "$commit_message" \
+  --arg body "$commit_body" \
+  --arg oid "$base_sha" \
+  --argjson additions "$additions" \
+  '{
+    query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+    variables: {
+      input: {
+        branch:          { repositoryNameWithOwner: $repo, branchName: $branch },
+        message:         { headline: $headline, body: $body },
+        expectedHeadOid: $oid,
+        fileChanges:     { additions: $additions }
+      }
+    }
+  }' | gh api graphql --input - > /dev/null
+
+pr_body="Upgrade from Zig ${current_version} to ${latest_version}."
+pr_url=$(
+  gh pr create \
+    -B main \
+    -H "$branch_name" \
+    --title "$commit_message" \
+    --body "$pr_body"
+)
+
+# The pull request exists now, the branch must not be deleted anymore in the trap, no matter what happens below.
+branch_created=false
+echo "Created pull request ${pr_url}."
+
+
+# Release notes are published for minor releases but not for every patch release, so only link them if they exist.
+release_notes_url="https://ziglang.org/download/${latest_version}/release-notes.html"
+if [[ "$(curl -sS --retry 3 -o /dev/null -w '%{http_code}' "$release_notes_url")" == 200 ]]; then
+  release_notes_link="[release notes for Zig ${latest_version}](${release_notes_url})"
+else
+  release_notes_link="[download page](https://ziglang.org/download/)"
+fi
+
+pr_comment=$(
+  cat << EOF
+Zig ${latest_version} has been released. This pull request updates the two Zig version references in this repository:
+* \`ZIG_VERSION\` in \`zig-version\`
+* \`.minimum_zig_version\` in \`build.zig.zon\`
+
+The automatically created commit does **not** migrate the code base to Zig ${latest_version}.
+The automatic creation of this pull request is mainly meant as a signal that a new Zig release is available.
+**Its initial CI run will most likely fail, which is expected**.
+
+Use it as a starting point for the migration. See the ${release_notes_link} for what has changed.
+
+This pull request has been created by the \`.github/workflows/update-zig.yaml\` workflow.
+EOF
+)
+gh pr comment "$pr_url" --body "$pr_comment" > /dev/null
+echo "Added the comment explaining that this pull request is not a migration to Zig ${latest_version}."

--- a/.github/workflows/update-zig.yaml
+++ b/.github/workflows/update-zig.yaml
@@ -1,0 +1,53 @@
+name: Automation - Check for New Zig Releases
+
+# Checks once a week whether a new stable Zig release is available and, if so, opens a pull request that updates
+# ZIG_VERSION in zig-version and .minimum_zig_version in build.zig.zon, and nothing else.
+#
+# The pull request is not an attempt to migrate the code base to the new Zig version, that cannot be automated: Zig
+# releases regularly come with breaking changes to the language and to the standard library. The pull request only
+# serves as a signal to the maintainers that a new Zig release is available, and as a starting point for the
+# migration, which the maintainers take care of however they see fit. The CI run for such a pull request will usually
+# fail, that is expected.
+
+on:
+  schedule:
+    - cron: "13 08 * * TUE" # weekly on Tuesday mornings UTC
+
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  check-for-new-zig-release:
+    name: check for a new Zig release and create a PR
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: github.repository == 'open-telemetry/opentelemetry-injector'
+    permissions:
+      contents: read # for actions/checkout
+    steps:
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: otelbot-token
+        with:
+          # We are deliberately not using the default secrets.GITHUB_TOKEN here, since events from that token do not
+          # trigger subsequent workflows, see
+          # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/trigger-a-workflow#triggering-a-workflow-from-a-workflow.
+          # That is, the pull request created by this workflow would not trigger .github/workflows/build.yml, and its
+          # (expected) failure is precisely the information the maintainers need to see here.
+          # See https://github.com/open-telemetry/community/blob/9eaa934620638a2f5537d3d74372b389098a8f5e/assets.md#otelbot.
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out the codebase
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The App token is only passed to the script below, which creates the branch, the commit and the pull request
+          # via the GitHub API instead of via git, so the token does not need to be persisted in the git config.
+          persist-credentials: false
+
+      - name: Check for a new Zig release and create a PR
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+        run: ./.github/workflows/scripts/update-zig.sh

--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,15 @@ injector-integration-tests-for-all-architectures:
 	injector-integration-tests/scripts/test-all.sh
 
 .PHONY: lint
-lint: zig-fmt-check zig-validate-test-imports shellcheck-lint
+lint: zig-fmt-check zig-validate-test-imports zig-version-check shellcheck-lint
+
+# Verifies that ZIG_VERSION in zig-version and .minimum_zig_version in build.zig.zon are in sync. Both files ask for
+# this in a comment, but the two are consumed by different toolchains (the container builds vs. CI and "zig build"),
+# so a mismatch does not necessarily show up as a build failure.
+.PHONY: zig-version-check
+zig-version-check:
+	@zig_version=$$(scripts/zig-version-check.sh) && \
+	  echo "the Zig version references are in sync at $$zig_version"
 
 .PHONY: zig-fmt-check
 zig-fmt-check: check-zig-installed

--- a/scripts/zig-version-check.sh
+++ b/scripts/zig-version-check.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Verifies that the two Zig version references in this repository agree with each other, and prints the version they
+# agree on to stdout.
+#
+# The two references drive different Zig toolchains, which is why a mismatch does not necessarily show up as a build
+# failure:
+#   * ZIG_VERSION in ./zig-version is the Zig version that Dockerfile and devel.Dockerfile download, and the version
+#     that CONTRIBUTING.md asks contributors to install locally.
+#   * .minimum_zig_version in ./build.zig.zon is the lower bound that "zig build" enforces, and it is also the version
+#     that mlugg/setup-zig installs in CI: .github/workflows/build.yml pins no version, and with an empty version
+#     input that action resolves the version from the minimum_zig_version field in build.zig.zon.
+# If the two drift apart, CI silently verifies and tests the injector with a different Zig version than the one the
+# container builds ("make dist") and contributors use.
+#
+# Both files carry a comment asking for them to be kept in sync. This script is what actually enforces it. It is
+# invoked from the make target zig-version-check (part of "make lint") and from
+# .github/workflows/scripts/update-zig.sh, which uses it to read the current Zig version.
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+zig_version_file=zig-version
+build_zig_zon_file=build.zig.zon
+
+# Matches a stable Zig version like "0.16.0".
+zig_version_regex='[0-9]+\.[0-9]+\.[0-9]+'
+
+# Note: the "|| true" in the two lookups below keeps grep finding no match from aborting the script via "set -e", so
+# that the checks for an empty result can report what exactly could not be determined.
+zig_version=$(grep -oE "^ZIG_VERSION=${zig_version_regex}$" "$zig_version_file" | head -n 1 | cut -d= -f2 || true)
+if [[ -z "$zig_version" ]]; then
+  echo "Error: cannot determine the Zig version from ZIG_VERSION in ./${zig_version_file}." >&2
+  exit 1
+fi
+
+minimum_zig_version=$(
+  grep -oE "\.minimum_zig_version = \"${zig_version_regex}\"" "$build_zig_zon_file" |
+    head -n 1 |
+    grep -oE "$zig_version_regex" ||
+    true
+)
+if [[ -z "$minimum_zig_version" ]]; then
+  echo "Error: cannot determine the Zig version from .minimum_zig_version in ./${build_zig_zon_file}." >&2
+  exit 1
+fi
+
+if [[ "$zig_version" != "$minimum_zig_version" ]]; then
+  echo "Error: the Zig version references in this repository are out of sync: ZIG_VERSION in ./${zig_version_file} is ${zig_version}, but .minimum_zig_version in ./${build_zig_zon_file} is ${minimum_zig_version}. Please set both to the same version." >&2
+  exit 1
+fi
+
+echo "$zig_version"


### PR DESCRIPTION
The new workflow creates a PR with one simple commit which bumps `ZIG_VERSION` in `zig-version` and `.minimum_zig_version` in `build.zig.zon`.

The automatically created commit does not migrate the code base to the new Zig version, this can hardly be automated. The automatic creation of the pull request is mainly meant as a signal that a new Zig release is available. Its initial CI run will most likely fail, which is expected.

Additionally, it adds a new "make lint" step that verifies that the two Zig versions agree. This was previously only a comment, now it is enforced in CI.